### PR TITLE
Add Discord link to navbar

### DIFF
--- a/_includes/partials/_nav-links.njk
+++ b/_includes/partials/_nav-links.njk
@@ -1,3 +1,4 @@
 <a href="https://colorjs.io">Color.js</a>
 <a href="https://github.com/color-js/apps">GitHub</a>
+<a href="https://discord.gg/K64FJBznq4">Discord</a>
 <a href="https://github.com/color-js/apps/issues/new" class="footer">File bug</a>


### PR DESCRIPTION
I figured this might be desirable in order to reflect the options on the main website.