### PR TITLE
Add CSS Rec2020 variant

### DIFF
--- a/gamut-mapping/gradients.js
+++ b/gamut-mapping/gradients.js
@@ -12,7 +12,7 @@ let app = createApp({
 		const urlToColor = params.get("to");
 		const from =  urlFromColor || "oklch(90% .4 250)";
 		const to = urlToColor || "oklch(40% .1 20)";
-		const methods = ["none", "clip", "scale-lh", "css", "raytrace", "edge-seeker", "chromium"];
+		const methods = ["none", "clip", "scale-lh", "css", "css-rec2020", "raytrace", "edge-seeker", "chromium"];
 		const runResults = {};
 		methods.forEach(method => runResults[method] = []);
 		return {

--- a/gamut-mapping/methods.js
+++ b/gamut-mapping/methods.js
@@ -19,6 +19,16 @@ const methods = {
 		label: "CSS",
 		description: "CSS Color 4 gamut mapping method.",
 	},
+	"css-rec2020": {
+		label: "CSS Rec2020",
+		description: "CSS Color 4 gamut mapping to rec2020, then Naïve clipping to the P3 gamut.",
+		compute: (color) => {
+			return color
+				.clone()
+				.toGamut({ space: "rec2020", method: "css" })
+				.toGamut({ space: "p3", method: "clip" });
+		},
+	},
 	"scale-lh": {
 		label: "Scale LH",
 		description: "Runs Scale, sets L, H to those of the original color, then runs Scale again.",


### PR DESCRIPTION
As [resolved](https://github.com/w3c/csswg-drafts/issues/9449#issuecomment-2162711081) today-

`RESOLVED: Gamut map all device independent color spaces to Rec.2020 for now, transforming from there to device gamut is undefined.`

This adds a variant of the CSS algorithm that only maps to `rec2020` before clipping to p3. This appears to behave quite similar to the Chromium variant.

Test: https://deploy-preview-5--color-apps.netlify.app/gamut-mapping/gradients