### PR TITLE
Fix colorchange error

### DIFF
--- a/gamut-mapping/map-color.js
+++ b/gamut-mapping/map-color.js
@@ -116,6 +116,11 @@ export default {
 	methods: {
 		toPrecision: Color.util.toPrecision,
 		abs: Math.abs,
+		colorchange (event) {
+			if (event.detail?.value) {
+				this.colorNullable = event.detail.value;
+			}
+		},
 	},
 
 	watch: {
@@ -145,7 +150,7 @@ export default {
 						<small class="description">The color as displayed directly by the browser.</small>
 					</dt>
 					<dd>
-						<color-swatch size="large" @colorchange="event => colorNullable = event.detail.color" :value="colorInput">
+						<color-swatch size="large" @colorchange="colorchange" :value="colorInput">
 							<input v-model="colorInput" />
 						</color-swatch>
 						<details class="space-coords">


### PR DESCRIPTION
The `<color-swatch>` element emits a `value` and not a `color`. I extracted this and added a bit more error handling, although it may negate the `colorNullable` logic in its current state.

Fixes #8 

https://deploy-preview-9--color-apps.netlify.app/gamut-mapping/?color=oklch(80%25+0.2+80)