### PR TITLE
Fix issues with the Gamut Mapping Playground & Experiments

### DIFF
--- a/gamut-mapping/gradients.js
+++ b/gamut-mapping/gradients.js
@@ -60,10 +60,10 @@ let app = createApp({
 
 	methods: {
 		colorChangeFrom (event) {
-			this.parsedFrom = event.detail?.value || this.parsedFrom;
+			this.parsedFrom = event.target.color || this.parsedFrom;
 		},
 		colorChangeTo (event) {
-			this.parsedTo = event.detail?.value || this.parsedTo;
+			this.parsedTo = event.target.color || this.parsedTo;
 		},
 		tryParse (input) {
 			try {

--- a/gamut-mapping/map-color.js
+++ b/gamut-mapping/map-color.js
@@ -179,7 +179,7 @@ export default {
 						<small v-if="config.description" class="description">{{ config.description }}</small>
 					</dt>
 					<dd>
-						<color-swatch size="large" :value="mapped[method].color"></color-swatch>
+						<color-swatch size="large" :color="mapped[method].color"></color-swatch>
 						<dl class="deltas" v-if="!Object.values(mapped[method].deltas).every(d => d === 0)">
 							<div v-for="(delta, c) of mapped[method].deltas" :class="'delta-' + c.toLowerCase()">
 								<dt>Δ{{ c }}</dt>

--- a/gamut-mapping/map-color.js
+++ b/gamut-mapping/map-color.js
@@ -145,7 +145,7 @@ export default {
 						<small class="description">The color as displayed directly by the browser.</small>
 					</dt>
 					<dd>
-						<color-swatch size="large" @colorchange="event => colorNullable = event.detail.color" :value="colorInput">
+						<color-swatch size="large" @colorchange="event => colorNullable = event.target.color" :value="colorInput">
 							<input v-model="colorInput" />
 						</color-swatch>
 						<details class="space-coords">
@@ -179,7 +179,7 @@ export default {
 						<small v-if="config.description" class="description">{{ config.description }}</small>
 					</dt>
 					<dd>
-						<color-swatch size="large" :color="mapped[method].color"></color-swatch>
+						<color-swatch size="large" :value="mapped[method].color"></color-swatch>
 						<dl class="deltas" v-if="!Object.values(mapped[method].deltas).every(d => d === 0)">
 							<div v-for="(delta, c) of mapped[method].deltas" :class="'delta-' + c.toLowerCase()">
 								<dt>Δ{{ c }}</dt>


### PR DESCRIPTION
Closes #6, #8

Even though [we already have a possible fix](https://github.com/color-js/apps/pull/9) for the issue, this PR is an attempt to fix the root of the issue, namely two things:

1) [When updating the value of `colorNullable` (on the color change)](https://github.com/color-js/apps/blob/99d284f9a2412ccbc87d0fee06097e8eac074bfe/gamut-mapping/map-color.js#L148), we should get the current `<color-swatch>` value not from the `colorchange` event's details, but from the swatch itself, i.e., from the event target.
2) [When setting `<color-swatch>` value](https://github.com/color-js/apps/blob/99d284f9a2412ccbc87d0fee06097e8eac074bfe/gamut-mapping/map-color.js#L182) we should bind its `value` attribute, not `color`. [The `color` attribute is not reflectable](https://github.com/color-js/elements/blob/1785a2ffa432b74dbb5871f117b30fca464fd4c7/src/color-swatch/color-swatch.js#L180).