### PR TITLE
[Colour Picker] Make the UI fades in when everything is ready

### DIFF
--- a/picker/index.js
+++ b/picker/index.js
@@ -101,3 +101,15 @@ document.addEventListener("click", evt => {
 		evt.target.select();
 	}
 });
+
+Promise.allSettled([
+	customElements.whenDefined("color-picker"),
+	customElements.whenDefined("space-picker"),
+	customElements.whenDefined("channel-slider"),
+	customElements.whenDefined("color-swatch"),
+]).then(() => {
+	// All components are registered now!
+	// Add the `ready` class so the UI fades in.
+	// Credit: https://www.abeautifulsite.net/posts/flash-of-undefined-custom-elements/
+	document.body.classList.add("ready");
+});

--- a/picker/index.js
+++ b/picker/index.js
@@ -101,15 +101,3 @@ document.addEventListener("click", evt => {
 		evt.target.select();
 	}
 });
-
-Promise.allSettled([
-	customElements.whenDefined("color-picker"),
-	customElements.whenDefined("space-picker"),
-	customElements.whenDefined("channel-slider"),
-	customElements.whenDefined("color-swatch"),
-]).then(() => {
-	// All components are registered now!
-	// Add the `ready` class so the UI fades in.
-	// Credit: https://www.abeautifulsite.net/posts/flash-of-undefined-custom-elements/
-	document.body.classList.add("ready");
-});

--- a/picker/style.css
+++ b/picker/style.css
@@ -41,6 +41,13 @@ main {
 	margin: 1em auto;
 	background: #f0f0f0;
 	box-shadow: .05em .05em .1em rgba(0,0,0,.2), 0 0 0 100vmax var(--color);
+	opacity: 0;
+
+	body.ready & {
+		opacity: 1;
+		/* UI appears in 0.25s in total. We add the 0.1s delay to let the `<color-picker>` components settle down. */
+		transition: opacity .15s .1s;
+  }
 }
 
 color-picker {

--- a/picker/style.css
+++ b/picker/style.css
@@ -43,11 +43,11 @@ main {
 	box-shadow: .05em .05em .1em rgba(0,0,0,.2), 0 0 0 100vmax var(--color);
 	opacity: 0;
 
-	body.ready & {
+	&:has(color-picker:defined) {
 		opacity: 1;
-		/* UI appears in 0.25s in total. We add the 0.1s delay to let the `<color-picker>` components settle down. */
-		transition: opacity .15s .1s;
-  }
+		/* We add the 0.3s delay to let the `<color-picker>` components settle down. */
+		transition: opacity .25s .3s;
+  	}
 }
 
 color-picker {


### PR DESCRIPTION
This should improve the UX. With the change, the UI loads like this:

https://github.com/user-attachments/assets/e6544a36-5726-4cc9-bdda-b0cf014fcb31

Live: https://deploy-preview-13--color-apps.netlify.app/picker/

