### PR TITLE
[Colour App] Use the `<color-picker>` swatch instead of `box-shadow` to show the color

### DIFF
--- a/picker/index.html
+++ b/picker/index.html
@@ -10,7 +10,7 @@
 	<script src="https://stretchy.verou.me/dist/stretchy.iife.min.js" data-stretchy-filter="autosize" async defer></script>
 </head>
 <body id="app">
-	<main :style="{ '--color': css_color }">
+	<main>
 		<header>
 			<h1>Colour Picker <button onclick="CSS_color_to_LCH()">Import color…</button></h1>
 		</header>

--- a/picker/style.css
+++ b/picker/style.css
@@ -1,8 +1,3 @@
-:root {
-	--transparency: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill-opacity=".05"><rect width="50" height="50" /><rect x="50" y="50" width="50" height="50" /></svg>')
-	0 0 / 20px 20px #f8f8f8;
-}
-
 body {
 	display: flex;
 	align-items: flex-start;
@@ -12,7 +7,6 @@ body {
 	padding: 1em 2em;
 	margin: 0;
 	font: 100%/1.6 Helvetica Neue, sans-serif;
-	background: var(--transparency);
 }
 
 header {
@@ -40,7 +34,6 @@ main {
 	max-width: 90vw;
 	margin: 1em auto;
 	background: #f0f0f0;
-	box-shadow: .05em .05em .1em rgba(0,0,0,.2), 0 0 0 100vmax var(--color);
 	opacity: 0;
 
 	&:has(color-picker:defined) {
@@ -92,6 +85,13 @@ color-picker {
 	}
 
 	&::part(swatch) {
+		border-radius: 0;
+		position: absolute;
+		inset: 0;
+		z-index: -1;
+	}
+
+	&::part(details) {
 		display: none;
 	}
 }


### PR DESCRIPTION
This allows us to show the color gamut:
https://deploy-preview-14--color-apps.netlify.app/picker/

<img width="884" alt="image" src="https://github.com/user-attachments/assets/9b96d5a7-2268-4900-b4ed-26717768357f" />
