### PR TITLE
[Colour Picker] Some improvements

### DIFF
--- a/picker/index.html
+++ b/picker/index.html
@@ -10,7 +10,7 @@
 	<script src="https://stretchy.verou.me/dist/stretchy.iife.min.js" data-stretchy-filter="autosize" async defer></script>
 </head>
 <body id="app">
-	<main>
+	<main :style="{ '--color': css_color }">
 		<header>
 			<h1>Colour Picker <button onclick="CSS_color_to_LCH()">Import color…</button></h1>
 		</header>

--- a/picker/index.html
+++ b/picker/index.html
@@ -12,7 +12,7 @@
 <body id="app">
 	<main :style="{ '--color': css_color }">
 		<header>
-			<h1>Colour Picker <button onclick="CSS_color_to_LCH()">Import color…</button></h1>
+			<h1>Colour Picker</h1>
 		</header>
 
 		<color-picker alpha @colorchange="color = $event.target.color" ref="picker"></color-picker>

--- a/picker/index.js
+++ b/picker/index.js
@@ -79,22 +79,6 @@ let app = createApp({
 	},
 }).mount("#app");
 
-window.CSS_color_to_LCH = function CSS_color_to_LCH (str) {
-	str = str || prompt("Enter any CSS color");
-
-	if (!str) {
-		return;
-	}
-
-	try {
-		app.$refs.picker.color = new Color(str).to(app.color.space);
-	}
-	catch (e) {
-		alert(e.message);
-		return;
-	}
-};
-
 // Select text in readonly input fields when you focus them
 document.addEventListener("click", evt => {
 	if (evt.target.matches("input[readonly]")) {

--- a/picker/style.css
+++ b/picker/style.css
@@ -1,3 +1,8 @@
+:root {
+	--transparency: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill-opacity=".05"><rect width="50" height="50" /><rect x="50" y="50" width="50" height="50" /></svg>')
+	0 0 / 20px 20px #f8f8f8;
+}
+
 body {
 	display: flex;
 	align-items: flex-start;
@@ -7,6 +12,7 @@ body {
 	padding: 1em 2em;
 	margin: 0;
 	font: 100%/1.6 Helvetica Neue, sans-serif;
+	background: var(--transparency);
 }
 
 header {
@@ -34,6 +40,7 @@ main {
 	max-width: 90vw;
 	margin: 1em auto;
 	background: #f0f0f0;
+	box-shadow: .05em .05em .1em rgba(0,0,0,.2), 0 0 0 100vmax var(--color);
 	opacity: 0;
 
 	&:has(color-picker:defined) {
@@ -73,7 +80,8 @@ color-picker {
 		text-overflow: ellipsis;
 	}
 
-	&::part(sliders) {
+	&::part(sliders),
+	&::part(details) {
 		grid-column: 1 / -1;
 	}
 
@@ -85,14 +93,16 @@ color-picker {
 	}
 
 	&::part(swatch) {
-		border-radius: 0;
-		position: absolute;
-		inset: 0;
-		z-index: -1;
+		/* We need the gamut badge to be placed absolutely relative to the body, not the color swatch */
+		display: contents;
 	}
 
-	&::part(details) {
+	&::part(swatch-base) {
 		display: none;
+	}
+
+	&::part(gamut) {
+		font-size: clamp(1rem, 2vw, 1.5rem);
 	}
 }
 

--- a/picker/style.css
+++ b/picker/style.css
@@ -21,18 +21,6 @@ header {
 	letter-spacing: -.05em;
 }
 
-	header button {
-		padding: .4em .6em;
-		border: 0;
-		margin: 0 .5em;
-		background: rgb(0 0 0 /.15);
-		border-radius: .3em;
-		font-weight: bold;
-		text-transform: uppercase;
-		vertical-align: .4em;
-		cursor: pointer;
-	}
-
 main {
 	padding: 1.5em;
 	border-radius: .5em;


### PR DESCRIPTION
- Allow users to edit the color via an input field (and remove the “Import Color” button)
- Make the gamut badge bigger

![image](https://github.com/user-attachments/assets/dd1c7e06-53eb-4789-beb2-4008aec66444)

- Use `box-shadow` to show the color instead of the absolutely positioned swatch: It makes the picker loading process smoother

<img width="573" alt="image" src="https://github.com/user-attachments/assets/069e75a1-a834-4902-9a6e-5ffd9586fa02" />


Live preview: https://deploy-preview-15--color-apps.netlify.app/picker/