### PR TITLE
Add Gamut Comparison app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 *.html
 !*.tpl.html
 !*/*.html
+!*/**/*.html

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ They are useful in their own right, but also serve as [Color.js](https://colorjs
 - [Convert across everything](convert)
 - [Gamut Mapping Gradients](gamut-mapping/gradients)
 - [Gamut Mapping Playground](gamut-mapping)
+- [Gamut Mapping Comparison](gamut-mapping/compare)
 - [Gradient interpolation](gradients)
 - [Named color proximity](named)
 

--- a/gamut-mapping/compare/index.html
+++ b/gamut-mapping/compare/index.html
@@ -33,7 +33,7 @@
         <ul>
           <li>edge: Edge Tracer, mapping to rec2020</li>
           <li>chromium: Chromium "baked in" implementation, mapping to rec2020</li>
-          <li>bjorn: Björn Ottosson method, mapping to p3</li>
+          <li>bjorn: Björn Ottosson method, mapping to rec2020</li>
           <li>raytrace: Raytrace, mapping to p3</li>
         </ul>
     </dl>

--- a/gamut-mapping/compare/index.html
+++ b/gamut-mapping/compare/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Color GMA Test</title>
+		<script type="module" src="script.js"></script>
+		<link rel="modulepreload" href="worker.js" />
+	</head>
+	<body>
+		<h1>GMA Comparison</h1>
+		<p>
+			This compares the output of different gamut mapping algorithms when
+			mapping to <code>rec2020</code>, and then clipping to <code>p3</code> and
+			<code>srgb</code> to approximate clipping to the display device.
+		</p>
+		<p>
+			It steps through the <code>xyz-d65</code> space with the provided delta,
+			and checks a color if it is outside of <code>rec2020</code>.
+		</p>
+    <dl>
+      <dt>Scales:</dt>
+      <dd>
+        <ul>
+          <li>L = 0-100 (So a 1 would be equivalent to 0.01 or 1%)</li>
+          <li>C = 0-0.4 (Most of the mapped colors had very high chroma to start with, so we're seeing large shifts here, as expected)</li>
+          <li>h = 0-360</li>
+
+        </ul>
+      </dd>
+      <dt>Algorithms:</dt>
+      <dd>
+        <ul>
+          <li>edge: Edge Tracer, mapping to rec2020</li>
+          <li>chromium: Chromium "baked in" implementation, mapping to rec2020</li>
+          <li>bjorn: Björn Ottosson method, mapping to p3</li>
+          <li>raytrace: Raytrace, mapping to p3</li>
+        </ul>
+    </dl>
+
+
+
+		<button id="run">Run</button>
+		<label for="delta">Delta</label>
+		<input
+			type="number"
+			id="delta"
+			value="0.03"
+			step="0.01"
+			min="0.01"
+			max="1"
+		/>
+
+		<pre id="output"></pre>
+	</body>
+</html>

--- a/gamut-mapping/compare/index.html
+++ b/gamut-mapping/compare/index.html
@@ -34,7 +34,8 @@
           <li>edge: Edge Tracer, mapping to rec2020</li>
           <li>chromium: Chromium "baked in" implementation, mapping to rec2020</li>
           <li>bjorn: Björn Ottosson method, mapping to rec2020</li>
-          <li>raytrace: Raytrace, mapping to p3</li>
+          <li>raytrace: Raytrace, mapping to rec2020</li>
+          <li>clip: Clipping directly to p3, as a comparison</li>
         </ul>
     </dl>
 

--- a/gamut-mapping/compare/script.js
+++ b/gamut-mapping/compare/script.js
@@ -1,0 +1,21 @@
+// @ts-check
+const worker = new Worker("./worker.js", { type: "module" });
+
+const output = document.getElementById("output");
+worker.onmessage = (message) => {
+	const data = JSON.parse(message.data);
+	if (data.results) {
+		output.innerHTML = JSON.stringify(data, null, 2) + "<br/><br/><br/><br/>";
+	}
+};
+worker.onerror = (...error) => {
+	console.error("Worker error:", error);
+	output.innerHTML = "Error: " + error.message;
+};
+
+const run = document.getElementById("run");
+run.addEventListener("click", () => {
+	const delta = parseFloat(document.getElementById("delta").value);
+	console.log("Running worker");
+	worker.postMessage(["run", { delta }]);
+});

--- a/gamut-mapping/compare/utils.js
+++ b/gamut-mapping/compare/utils.js
@@ -63,6 +63,6 @@ export const runningAverage = (average, newValue, count) => {
 
 export const chromiumColor = (color) => methods.chromium.compute(color);
 
-export const bjornColor = (color) => methods.bjorn.compute(color);
+export const bjornColor = (color) => methods.bjornRec2020.compute(color);
 
 export const raytraceColor = (color) => methods["raytrace"].compute(color);

--- a/gamut-mapping/compare/utils.js
+++ b/gamut-mapping/compare/utils.js
@@ -1,0 +1,68 @@
+// @ts-check
+import Color from "https://colorjs.io/dist/color.js";
+import methods from "../methods.js";
+
+export function* xyzColorGenerator(settings) {
+	let count = 0;
+	for (var x = settings.x.min; x <= settings.x.max; x = x + settings.x.delta) {
+		for (
+			var y = settings.y.min;
+			y <= settings.y.max;
+			y = y + settings.y.delta
+		) {
+			for (
+				var z = settings.z.min;
+				z <= settings.z.max;
+				z = z + settings.z.delta
+			) {
+				yield [`color(xyz ${x} ${y} ${z})`, count++];
+			}
+		}
+	}
+}
+
+export const deltas = (original, mapped) => {
+	let deltas = {};
+	["L", "C", "H"].forEach((c, i) => {
+		let delta = mapped.to("oklch").coords[i] - original.to("oklch").coords[i];
+
+		if (c === "L") {
+			// L is percentage
+			delta *= 100;
+		} else if (c === "H") {
+			// Hue is angular, so we need to normalize it
+			delta = ((delta % 360) + 720) % 360;
+			delta = Math.min(360 - delta, delta);
+			// Check: Is this hiding cases where only one value is NaN?
+			if (isNaN(delta)) delta = 0;
+		} else {
+			// debugger;
+		}
+
+		// delta = Color.util.toPrecision(delta, 2);
+		// Use absolute because we are interested in magnitude, not direction
+		deltas[c] = Math.abs(delta);
+	});
+	deltas.delta2000 = original.deltaE(mapped, { method: "2000" });
+	return deltas;
+};
+
+export const clipP3 = (color) =>
+	color.clone().toGamut({ space: "p3", method: "clip" });
+export const clipSrgb = (color) =>
+	color.clone().toGamut({ space: "srgb", method: "clip" });
+
+export const edgeSeekerColor = (color) => methods["edge-seeker-rec2020"].compute(color);
+
+export const runningAverage = (average, newValue, count) => {
+	if (count === 1) {
+		return newValue;
+	}
+	return (average * (count - 1)) / count + newValue / count;
+};
+
+export const chromiumColor = (color) => methods.chromium.compute(color);
+
+export const bjornColor = (color) => methods.bjorn.compute(color);
+
+export const raytraceColor = (color) => methods["raytrace"].compute(color);

--- a/gamut-mapping/compare/utils.js
+++ b/gamut-mapping/compare/utils.js
@@ -65,4 +65,4 @@ export const chromiumColor = (color) => methods.chromium.compute(color);
 
 export const bjornColor = (color) => methods.bjornRec2020.compute(color);
 
-export const raytraceColor = (color) => methods["raytrace"].compute(color);
+export const raytraceColor = (color) => methods.raytraceRec2020.compute(color);

--- a/gamut-mapping/compare/worker.js
+++ b/gamut-mapping/compare/worker.js
@@ -68,13 +68,12 @@ const run = ({delta}) => {
 
 const processColor = (color) => {
 	const edgeSeeker = edgeSeekerColor(color);
-	const edgeDelta = deltas(color, edgeSeeker);
+	const edgeClippedToP3 = clipP3(edgeSeeker);
+	const edgeClippedToSrgb = clipSrgb(edgeSeeker);
+	const edgeP3Delta = deltas(color, edgeClippedToP3);
+	const edgeSrgbDelta = deltas(color, edgeClippedToSrgb);
 
-	const clippedToP3 = clipP3(edgeSeeker);
-	const clippedToSrgb = clipSrgb(edgeSeeker);
 	const clippedStraightToP3 = clipP3(color);
-	const p3Delta = deltas(color, clippedToP3);
-	const srgbDelta = deltas(color, clippedToSrgb);
 	const clippedStraightToP3Delta = deltas(color, clippedStraightToP3);
 	const chromiumClippedToP3 = chromiumColor(color);
 	const chromiumClippedToSrgb = clipSrgb(chromiumClippedToP3);
@@ -94,12 +93,11 @@ const processColor = (color) => {
 	return {
 		color,
 		edgeSeeker,
-		edgeDelta,
-		clippedToP3,
-		clippedToSrgb,
+		edgeClippedToP3,
+		edgeClippedToSrgb,
 		clippedStraightToP3,
-		p3Delta,
-		srgbDelta,
+		edgeP3Delta,
+		edgeSrgbDelta,
 		clippedStraightToP3Delta,
 		chromiumClippedToP3,
 		chromiumClippedToSrgb,
@@ -116,9 +114,9 @@ const processColor = (color) => {
 
 const aggregate = (colorData, index) => {
 	const {
-		p3Delta,
+		edgeP3Delta,
 		clippedStraightToP3Delta,
-		srgbDelta,
+		edgeSrgbDelta,
 		chromiumP3Delta,
 		chromiumSrgbDelta,
 		bjornP3Delta,
@@ -128,15 +126,15 @@ const aggregate = (colorData, index) => {
 	} = colorData;
 
 	const map = [
-		["edgeToP3", p3Delta],
-		["clipToP3", clippedStraightToP3Delta],
-		["edgeToSrgb", srgbDelta],
+		["edgeToP3", edgeP3Delta],
+		["edgeToSrgb", edgeSrgbDelta],
 		["chromiumToP3", chromiumP3Delta],
 		["chromiumToSrgb", chromiumSrgbDelta],
 		["bjornToP3", bjornP3Delta],
 		["bjornToSrgb", bjornSrgbDelta],
 		["raytraceToP3", raytraceP3Delta],
 		["raytraceToSrgb", raytraceSrgbDelta],
+		["clipToP3", clippedStraightToP3Delta],
 	];
 
 	map.forEach(([key, delta]) => {

--- a/gamut-mapping/compare/worker.js
+++ b/gamut-mapping/compare/worker.js
@@ -144,40 +144,7 @@ const aggregate = (colorData, index) => {
 		["L", "C", "H", "delta2000"].forEach((d) => {
 			res[d] = runningAverage(res[d], delta[d], index);
 		});
-
-		// Update worst case
-		// if (!res.worst || res.worst.delta2000 < delta.delta2000) {
-		//   res.worst = {
-		//     color: colorData.color.toString(),
-		//     delta2000: delta.delta2000,
-		//     L: delta.L,
-		//     C: delta.C,
-		//     H: delta.H,
-		//   };
-		// }
 	});
-
-	// // To P3 Edge
-	// const p3Res = results.edgeToP3;
-	// ["L", "C", "H", "delta2000"].forEach((delta) => {
-	//   p3Res[delta] = runningAverage(p3Res[delta], p3Delta[delta], index);
-	// });
-
-	// // To P3 clip
-	// const clipP3Res = results.clipToP3;
-	// ["L", "C", "H", "delta2000"].forEach((delta) => {
-	//   clipP3Res[delta] = runningAverage(
-	//     clipP3Res[delta],
-	//     clippedStraightToP3Delta[delta],
-	//     index
-	//   );
-	// });
-
-	// // To sRGB Edge
-	// const srgbRes = results.edgeToSrgb;
-	// ["L", "C", "H", "delta2000"].forEach((delta) => {
-	//   srgbRes[delta] = runningAverage(srgbRes[delta], srgbDelta[delta], index);
-	// });
 
 	return results;
 };

--- a/gamut-mapping/compare/worker.js
+++ b/gamut-mapping/compare/worker.js
@@ -1,0 +1,190 @@
+// @ts-check
+import Color from "https://colorjs.io/dist/color.js";
+
+import {
+	xyzColorGenerator,
+	deltas,
+	edgeSeekerColor,
+	clipP3,
+	clipSrgb,
+	runningAverage,
+	chromiumColor,
+	bjornColor,
+	raytraceColor,
+} from "./utils.js";
+
+const settings = (delta)=> ({
+	x: { min: 0, max: 1, delta },
+	y: { min: 0, max: 1, delta },
+	z: { min: 0, max: 1, delta },
+});
+const results = {
+	edgeToP3: { L: 0, C: 0, H: 0, delta2000: 0 },
+	edgeToSrgb: { L: 0, C: 0, H: 0, delta2000: 0 },
+	chromiumToP3: { L: 0, C: 0, H: 0, delta2000: 0 },
+	chromiumToSrgb: { L: 0, C: 0, H: 0, delta2000: 0 },
+	bjornToP3: { L: 0, C: 0, H: 0, delta2000: 0 },
+	bjornToSrgb: { L: 0, C: 0, H: 0, delta2000: 0 },
+	clipToP3: { L: 0, C: 0, H: 0, delta2000: 0 },
+	raytraceToP3: { L: 0, C: 0, H: 0, delta2000: 0 },
+	raytraceToSrgb: { L: 0, C: 0, H: 0, delta2000: 0 },
+	delta: null
+};
+
+const rawResults = [];
+
+// methods:
+// - edge to rec2020, clip to p3
+// - edge to rec2020, clip to srgb
+// - clip to p3
+// - clip to srgb
+
+const run = ({delta}) => {
+	const colors = xyzColorGenerator(settings(delta));
+	results.delta = delta;
+	let color = colors.next();
+	let count = 0;
+
+	while (!color.done) {
+		const [colorString, index] = color.value;
+		count = index;
+		let _color = new Color(colorString);
+		if (_color.inGamut("rec2020", { epsilon: 0 })) {
+			color = colors.next();
+			continue; // Skip colors in rec2020 gamut
+		}
+
+		const colorData = processColor(_color);
+		// rawResults.push({ colorString, colorData });
+		aggregate(colorData, index);
+
+		color = colors.next();
+		if (index % 100 === 0) {
+			postMessage(JSON.stringify({ results, count: index }));
+		}
+	}
+	postMessage(JSON.stringify({ results, count }));
+};
+
+const processColor = (color) => {
+	const edgeSeeker = edgeSeekerColor(color);
+	const edgeDelta = deltas(color, edgeSeeker);
+
+	const clippedToP3 = clipP3(edgeSeeker);
+	const clippedToSrgb = clipSrgb(edgeSeeker);
+	const clippedStraightToP3 = clipP3(color);
+	const p3Delta = deltas(color, clippedToP3);
+	const srgbDelta = deltas(color, clippedToSrgb);
+	const clippedStraightToP3Delta = deltas(color, clippedStraightToP3);
+	const chromiumClippedToP3 = chromiumColor(color);
+	const chromiumClippedToSrgb = clipSrgb(chromiumClippedToP3);
+	const chromiumP3Delta = deltas(color, chromiumClippedToP3);
+	const chromiumSrgbDelta = deltas(color, chromiumClippedToSrgb);
+	const bjornClippedToP3 = bjornColor(color);
+	const bjornClippedToSrgb = clipSrgb(bjornClippedToP3);
+	const bjornP3Delta = deltas(color, bjornClippedToP3);
+	const bjornSrgbDelta = deltas(color, bjornClippedToSrgb);
+
+	const raytrace = raytraceColor(color);
+	const raytraceClippedToP3 = clipP3(raytrace);
+	const raytraceClippedToSrgb = clipSrgb(raytrace);
+	const raytraceP3Delta = deltas(color, raytraceClippedToP3);
+	const raytraceSrgbDelta = deltas(color, raytraceClippedToSrgb);
+
+	return {
+		color,
+		edgeSeeker,
+		edgeDelta,
+		clippedToP3,
+		clippedToSrgb,
+		clippedStraightToP3,
+		p3Delta,
+		srgbDelta,
+		clippedStraightToP3Delta,
+		chromiumClippedToP3,
+		chromiumClippedToSrgb,
+		chromiumP3Delta,
+		chromiumSrgbDelta,
+		bjornClippedToP3,
+		bjornClippedToSrgb,
+		bjornP3Delta,
+		bjornSrgbDelta,
+		raytraceP3Delta,
+		raytraceSrgbDelta,
+	};
+};
+
+const aggregate = (colorData, index) => {
+	const {
+		p3Delta,
+		clippedStraightToP3Delta,
+		srgbDelta,
+		chromiumP3Delta,
+		chromiumSrgbDelta,
+		bjornP3Delta,
+		bjornSrgbDelta,
+		raytraceP3Delta,
+		raytraceSrgbDelta,
+	} = colorData;
+
+	const map = [
+		["edgeToP3", p3Delta],
+		["clipToP3", clippedStraightToP3Delta],
+		["edgeToSrgb", srgbDelta],
+		["chromiumToP3", chromiumP3Delta],
+		["chromiumToSrgb", chromiumSrgbDelta],
+		["bjornToP3", bjornP3Delta],
+		["bjornToSrgb", bjornSrgbDelta],
+		["raytraceToP3", raytraceP3Delta],
+		["raytraceToSrgb", raytraceSrgbDelta],
+	];
+
+	map.forEach(([key, delta]) => {
+		const res = results[key];
+		["L", "C", "H", "delta2000"].forEach((d) => {
+			res[d] = runningAverage(res[d], delta[d], index);
+		});
+
+		// Update worst case
+		// if (!res.worst || res.worst.delta2000 < delta.delta2000) {
+		//   res.worst = {
+		//     color: colorData.color.toString(),
+		//     delta2000: delta.delta2000,
+		//     L: delta.L,
+		//     C: delta.C,
+		//     H: delta.H,
+		//   };
+		// }
+	});
+
+	// // To P3 Edge
+	// const p3Res = results.edgeToP3;
+	// ["L", "C", "H", "delta2000"].forEach((delta) => {
+	//   p3Res[delta] = runningAverage(p3Res[delta], p3Delta[delta], index);
+	// });
+
+	// // To P3 clip
+	// const clipP3Res = results.clipToP3;
+	// ["L", "C", "H", "delta2000"].forEach((delta) => {
+	//   clipP3Res[delta] = runningAverage(
+	//     clipP3Res[delta],
+	//     clippedStraightToP3Delta[delta],
+	//     index
+	//   );
+	// });
+
+	// // To sRGB Edge
+	// const srgbRes = results.edgeToSrgb;
+	// ["L", "C", "H", "delta2000"].forEach((delta) => {
+	//   srgbRes[delta] = runningAverage(srgbRes[delta], srgbDelta[delta], index);
+	// });
+
+	return results;
+};
+
+onmessage = (event) => {
+	console.log("Message received from main script - compare", event, event.data);
+	if (event.data[0] === "run") {
+		run(event.data[1]);
+	}
+};

--- a/gamut-mapping/compare/worker.js
+++ b/gamut-mapping/compare/worker.js
@@ -75,12 +75,15 @@ const processColor = (color) => {
 
 	const clippedStraightToP3 = clipP3(color);
 	const clippedStraightToP3Delta = deltas(color, clippedStraightToP3);
+
 	const chromiumClippedToP3 = chromiumColor(color);
 	const chromiumClippedToSrgb = clipSrgb(chromiumClippedToP3);
 	const chromiumP3Delta = deltas(color, chromiumClippedToP3);
 	const chromiumSrgbDelta = deltas(color, chromiumClippedToSrgb);
-	const bjornClippedToP3 = bjornColor(color);
-	const bjornClippedToSrgb = clipSrgb(bjornClippedToP3);
+
+	const bjorn = bjornColor(color);
+	const bjornClippedToP3 = clipP3(bjorn);
+	const bjornClippedToSrgb = clipSrgb(bjorn);
 	const bjornP3Delta = deltas(color, bjornClippedToP3);
 	const bjornSrgbDelta = deltas(color, bjornClippedToSrgb);
 

--- a/gamut-mapping/gradients.css
+++ b/gamut-mapping/gradients.css
@@ -79,5 +79,10 @@ details.timing-info {
 		justify-content: space-between;
 		gap: 1em;
 	}
+}
 
+#algorithms{
+	label{
+		margin-inline-end: 1em;
+	}
 }

--- a/gamut-mapping/gradients.html
+++ b/gamut-mapping/gradients.html
@@ -23,6 +23,13 @@
 		<input v-model="maxDeltaE" type="number" min="1" name="maxDeltaE"/><br/>
 		<div>{{steps.length}} Gradient Steps</div>
 		<label for="flush">Flush:</label> <input type="checkbox" v-model="flush" name="flush">
+		<details id="algorithms">
+			<summary>Algorithms</summary>
+			<label v-for="method in methods" :key="method">
+				<input type="checkbox" v-model="enabledMethods" :value="method" />
+				{{ method }}
+			</label>
+		</details>
 	</div>
 	<div class="color-inputs">
 		<color-swatch size="large" @colorchange="colorChangeFrom" :value="from">
@@ -46,8 +53,8 @@
 			<div v-for="[title, step] in oogSteps" :style="{'--step-color': step}" :title="title"></div>
 		</div>
 	</div>
-	<div :class="{flush, 'gradients': true}">
-		<article class="method" v-for="(i, method) of methods">
+	<div :class="{flush, 'gradients': true}" :key="refresh">
+		<article class="method" v-for="(i, method) of enabledMethods">
 			<mapped-gradient :key="i" :steps="steps" :method="i" @report-time="reportTime"/>
 		</article>
 	</div>

--- a/gamut-mapping/gradients.js
+++ b/gamut-mapping/gradients.js
@@ -12,11 +12,13 @@ let app = createApp({
 		const urlToColor = params.get("to");
 		const from =  urlFromColor || "oklch(90% .4 250)";
 		const to = urlToColor || "oklch(40% .1 20)";
-		const methods = ["none", "clip", "scale-lh", "css", "css-rec2020", "raytrace", "bjorn", "edge-seeker", "chromium"];
+		const methods = ["none", "clip", "scale-lh", "css", "css-rec2020", "raytrace", "raytraceRec2020", "bjorn", "bjornRec2020", "edge-seeker", "edge-seeker-rec2020", "chromium"];
+		const enabledMethods = ["clip", "css-rec2020", "raytraceRec2020", "bjornRec2020", "edge-seeker-rec2020", "chromium"];
 		const runResults = {};
-		methods.forEach(method => runResults[method] = []);
+		enabledMethods.forEach(method => runResults[method] = []);
 		return {
-			methods: methods,
+			methods,
+			enabledMethods,
 			from: from,
 			to: to,
 			parsedFrom: this.tryParse(from),
@@ -27,6 +29,7 @@ let app = createApp({
 			params: params,
 			interpolationSpaces: ["oklch", "oklab", "p3", "rec2020", "lab"],
 			runResults: runResults,
+			refresh: 0,
 		};
 	},
 
@@ -97,6 +100,12 @@ let app = createApp({
 			deep: true,
 			immediate: true,
 		},
+		enabledMethods(newValue) {
+			const runResults = {};
+			newValue.forEach(method => runResults[method] = []);
+			this.runResults = runResults;
+			this.refresh++;
+		}
 	},
 
 	components: {

--- a/gamut-mapping/methods.js
+++ b/gamut-mapping/methods.js
@@ -524,8 +524,8 @@ const methods = {
 			if (c > maxChroma) {
 				c = maxChroma;
 			}
-			// At this point it is safe to clip the values
-			return new Color("oklch", [l, c, h]).toGamut({ space: "p3", method: "clip" });
+			// Don't clip, and return rec2020 gamut
+			return new Color("oklch", [l, c, h]);
 		},
 	},
 	// "scale125": {

--- a/gamut-mapping/methods.js
+++ b/gamut-mapping/methods.js
@@ -11,6 +11,10 @@ const p3EdgeSeeker = makeEdgeSeeker((r, g, b) => {
 	const [l, c, h = 0] = new Color("p3", [r, g, b]).to("oklch").coords;
 	return { l, c, h };
 });
+const rec2020EdgeSeeker = makeEdgeSeeker((r, g, b) => {
+	const [l, c, h = 0] = new Color("rec2020", [r, g, b]).to("oklch").coords;
+	return { l, c, h };
+});
 
 const methods = {
 	"clip": {
@@ -488,7 +492,7 @@ const methods = {
 	},
 	"edge-seeker": {
 		label: "Edge Seeker",
-		description: "Using a LUT to detect edges of the gamut and reduce chroma accordingly.",
+		description: "Using a LUT to detect edges of the p3 gamut and reduce chroma accordingly.",
 		compute: (color) => {
 			let [l, c, h] = color.to("oklch").coords;
 			if (l <= 0) {
@@ -498,6 +502,25 @@ const methods = {
 				return new Color("oklch", [1, 0, h]);
 			}
 			let maxChroma = p3EdgeSeeker(l, h || 0);
+			if (c > maxChroma) {
+				c = maxChroma;
+			}
+			// At this point it is safe to clip the values
+			return new Color("oklch", [l, c, h]).toGamut({ space: "p3", method: "clip" });
+		},
+	},
+	"edge-seeker-rec2020": {
+		label: "Edge Seeker rec2020",
+		description: "Using a LUT to detect edges of the rec2020 gamut and reduce chroma accordingly.",
+		compute: (color) => {
+			let [l, c, h] = color.to("oklch").coords;
+			if (l <= 0) {
+				return new Color("oklch", [0, 0, h]);
+			}
+			if (l >= 1) {
+				return new Color("oklch", [1, 0, h]);
+			}
+			let maxChroma = rec2020EdgeSeeker(l, h || 0);
 			if (c > maxChroma) {
 				c = maxChroma;
 			}

--- a/gamut-mapping/methods.js
+++ b/gamut-mapping/methods.js
@@ -196,7 +196,7 @@ const methods = {
 		},
 	},
 	"bjorn" : {
-		label: "Björn Ottosson",
+		label: "Björn Ottosson P3",
 		description: "Approach using Oklab as defined by the creator of Oklab, Bjorn Ottosson. Projected toward constant lightness.",
 		lmsToP3Linear: [
 			[ 3.1277689713618737, -2.2571357625916377,  0.1293667912297650],
@@ -272,6 +272,85 @@ const methods = {
 
 			// Convert back to P3 and clip.
 			return oklab.to('p3').toGamut({method: 'clip'});
+		},
+	},
+	"bjornRec2020" : {
+		label: "Björn Ottosson Rec2020",
+		description: "Approach using Oklab as defined by the creator of Oklab, Bjorn Ottosson. Projected toward constant lightness.",
+		lmsToRec2020Linear: [
+			[2.1399067304346517, -1.2463894937606181, 0.10648276332596672],
+			[-0.8847358357577675, 2.1632309383612007, -0.27849510260343346],
+			[-0.04857374640044416, -0.454503149714096, 1.5030768961145402],
+		],
+		rec2020Coeff: [
+			// Red
+			[
+				// Limit
+				[-1.36834899, -0.46664773],
+				// `Kn` coefficients
+				[1.2572445, 1.71580176, 0.5648733,  0.79507316, 0.58716363],
+			],
+			// Green
+			[
+				// Limit
+				[2.01150796, -2.0379096],
+				// `Kn` coefficients
+				[0.74087755, -0.4586733, 0.08182977, 0.12598705, -0.14570327],
+			],
+			// Blue
+			[
+				// Limit
+				[0.06454093, 2.29709336],
+				// `Kn` coefficients
+				[1.36920484e+00, -1.64666735e-02, -1.14197870e+00, -5.01064768e-01, 1.19905985e-03],
+			],
+		],
+		compute: (color) => {
+			// Approach described in https://bottosson.github.io/posts/gamutclipping/
+			// For comparison against CSS approaches, constant lightness was used.
+			let oklab = color.to("oklab");
+
+			// Clamp lightness and see if we are in gamut.
+			oklab.l = util.clamp(0.0, oklab.l, 1.0);  // If doing adaptive lightness, this might not be wanted.
+			if (oklab.inGamut("rec2020", { epsilon: 0 })) {
+				return oklab.to("rec2020");
+			}
+
+			// Get coordinates and calculate chroma
+			let [l, a, b] = oklab.coords;
+			// Bjorn used 0.00001, are there issues with 0.0?
+			const epsilon = 0.0
+			let c = Math.max(epsilon, Math.sqrt(a ** 2 + b ** 2));
+
+			// Normalize a and b
+			if (c) {
+				a /= c;
+				b /= c;
+			}
+
+			// Get gamut specific transform from LMS to RGB and related coefficients
+			const lmsToLinear = methods.bjornRec2020.lmsToRec2020Linear;
+			const coeff = methods.bjornRec2020.rec2020Coeff;
+
+			// Find the lightness and chroma for the cusp.
+			let cusp = findCusp(a, b, lmsToLinear, coeff);
+
+			// Set the target lightness towards which chroma reduction will take place.
+			// `cusp[0]` is approximate lightness of cusp, l is current lightness.
+			// One could apply some adaptive lightness if desired.
+			const target = l; // cusp[0];
+			const t = findGamutIntersection(a, b, l, c, target, lmsToLinear, coeff, cusp);
+
+			// Adjust lightness and chroma
+			if (target !== l) {
+				oklab.l = target * (1 - t) + t * l;
+			}
+			c *= t;
+			oklab.a = c * a;
+			oklab.b = c * b;
+
+			// Convert back to rec2020 and clip.
+			return oklab.to("rec2020").toGamut({method: "clip"});
 		},
 	},
 	"raytrace": {

--- a/gamut-mapping/timing-info.js
+++ b/gamut-mapping/timing-info.js
@@ -8,10 +8,11 @@ export default {
 
 	computed: {
 		results () {
-			const [none, ...methodsTested] = Object.keys(this.runResults);
+			const methodsTested = Object.keys(this.runResults).filter(method => method !== "none");
+
 			return methodsTested.map(method => {
-				const data = this.runResults[method];
-				const total = data.reduce((acc, value) => acc + value);
+				const data = this.runResults[method] ?? [];
+				const total = data.reduce((acc, value) => acc + value, 0);
 
 				return {
 					id: method,


### PR DESCRIPTION
This provides a tool for comparing the gamut mapping algorithms. 

It also adds rec2020 variations of the Edge Seeker, Raytrace, and Björn GMAs. These are in the Playground, but not the gradient tool. 

https://deploy-preview-22--color-apps.netlify.app/gamut-mapping/compare/