### PR TITLE
Make gamut wheel responsive to fix mobile distortion

### DIFF
--- a/gamut/index.html
+++ b/gamut/index.html
@@ -9,14 +9,6 @@
 	<link rel="stylesheet" href="style.css">
 </head>
 <body>
-	<header>
-		<h1>OKLCH Gamut Wheel</h1>
-		<p>Slice of the P3 gamut at the picked lightness.
-			Hue runs around the wheel; <strong>distance from the center is chroma</strong>
-			(0 at the center, {{ maxChroma }} at the edge).
-			Grey = out of gamut.</p>
-	</header>
-
 	<main>
 		<color-picker space="oklch" color="oklch(0.5 0.2 240)" @colorchange="onColorChange"></color-picker>
 

--- a/gamut/style.css
+++ b/gamut/style.css
@@ -10,7 +10,7 @@ main {
 	flex-wrap: wrap;
 	align-items: center;
 	justify-content: center;
-	gap: 2em 1.5em;
+	gap: 1em 4em;
 }
 
 .controls {

--- a/gamut/style.css
+++ b/gamut/style.css
@@ -10,7 +10,7 @@ main {
 	flex-wrap: wrap;
 	align-items: center;
 	justify-content: center;
-	gap: 1em 4em;
+	gap: 1.5em 4em;
 }
 
 .controls {

--- a/gamut/style.css
+++ b/gamut/style.css
@@ -31,7 +31,11 @@ color-picker {
 .wheel-wrap {
 	position: relative;
 	width: var(--size);
-	height: var(--size);
+	/* Stay square when shrunk on narrow viewports, and reserve space on each side
+	   for the h=0°/180° labels which sit ~1.6em outside the wheel. */
+	max-width: calc(100% - 6em);
+	aspect-ratio: 1;
+	container-type: inline-size;
 	/* OOG backdrop: the layers paint `transparent` outside their in-gamut hue ranges,
 	   so this colour shows through anywhere the gamut doesn't reach. */
 	background: light-dark(#d8d8d8, #2c2c2c);
@@ -96,7 +100,7 @@ color-picker {
 		border: 2px solid white;
 		box-shadow: 0 0 0 1px rgb(0 0 0 / 0.4), 0 1px 2px rgb(0 0 0 / 0.4);
 		pointer-events: none;
-		--r: calc(min(var(--marker-c) / var(--max-c), 1) * var(--size) / 2);
+		--r: calc(min(var(--marker-c) / var(--max-c), 1) * 50cqi);
 		transform:
 			rotate(calc(-1 * var(--marker-h)))
 			translateX(var(--r))
@@ -115,6 +119,6 @@ color-picker {
 		font-size: 0.8em;
 		color: color-mix(in oklch, currentColor, transparent 40%);
 		translate: -50% -50%;
-		transform: rotate(calc(-1 * var(--angle))) translateX(calc(var(--size) / 2 + 1.6em)) rotate(var(--angle));
+		transform: rotate(calc(-1 * var(--angle))) translateX(calc(50cqi + 1.6em)) rotate(var(--angle));
 	}
 }

--- a/gamut/style.css
+++ b/gamut/style.css
@@ -31,9 +31,7 @@ color-picker {
 .wheel-wrap {
 	position: relative;
 	width: var(--size);
-	/* Stay square when shrunk on narrow viewports, and reserve space on each side
-	   for the h=0°/180° labels which sit ~1.6em outside the wheel. */
-	max-width: calc(100% - 6em);
+	max-width: 100%;
 	aspect-ratio: 1;
 	container-type: inline-size;
 	/* OOG backdrop: the layers paint `transparent` outside their in-gamut hue ranges,
@@ -101,10 +99,9 @@ color-picker {
 		box-shadow: 0 0 0 1px rgb(0 0 0 / 0.4), 0 1px 2px rgb(0 0 0 / 0.4);
 		pointer-events: none;
 		--r: calc(min(var(--marker-c) / var(--max-c), 1) * 50cqi);
-		transform:
-			rotate(calc(-1 * var(--marker-h)))
-			translateX(var(--r))
-			rotate(var(--marker-h));
+		translate:
+			calc(var(--r) * cos(var(--marker-h)))
+			calc(var(--r) * sin(var(--marker-h)) * -1);
 	}
 }
 
@@ -118,7 +115,14 @@ color-picker {
 		inset: 50% auto auto 50%;
 		font-size: 0.8em;
 		color: color-mix(in oklch, currentColor, transparent 40%);
-		translate: -50% -50%;
-		transform: rotate(calc(-1 * var(--angle))) translateX(calc(50cqi + 1.6em)) rotate(var(--angle));
+		--r: calc(50cqi + 1.6em);
+		translate:
+			calc(-50% + var(--r) * cos(var(--angle)))
+			calc(-50% - var(--r) * sin(var(--angle)));
+	}
+
+	/* h=0° / h=180° sit on the horizontal axis and overflow narrow viewports. */
+	@container (max-width: 32em) {
+		span:nth-child(odd) { display: none; }
 	}
 }

--- a/gamut/style.css
+++ b/gamut/style.css
@@ -5,17 +5,12 @@ body {
 	padding: 1em;
 }
 
-header p {
-	color: color-mix(in oklch, currentColor, transparent 30%);
-	max-width: 50em;
-}
-
 main {
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
 	justify-content: center;
-	gap: 2em 4em;
+	gap: 2em 1.5em;
 }
 
 .controls {


### PR DESCRIPTION
The wheel had fixed 520x520 px dimensions; on narrow viewports flexbox
would shrink the width but leave the height alone, producing a tall
oval. The h-labels also pushed past the viewport edge.

Switch the wrap to a max-width with `aspect-ratio: 1`, declare it as a
container-query container, and replace `var(--size) / 2` in the marker
and label transforms with `50cqi` so they track the actual rendered
radius. The 6em max-width inset reserves room for the h=0°/180° labels
that sit just outside the wheel.