### PR TITLE
Fix gamut wheel breaking when picker space changes

### DIFF
--- a/gamut/index.js
+++ b/gamut/index.js
@@ -111,7 +111,8 @@ globalThis.app = createApp({
 
 	methods: {
 		onColorChange (e) {
-			let [l, c, h] = e.target.color.coords;
+			// Picker may be in any space; convert so our (L, C, H) state stays in oklch.
+			let [l, c, h] = e.target.color.to("oklch").coords;
 			this.lightness = l;
 			this.markerC = c || 0;
 			this.markerH = h || 0;


### PR DESCRIPTION
The color-picker lets users switch color spaces, but onColorChange was
reading e.target.color.coords as if always [L, C, H] in oklch. After
switching to e.g. lab or srgb, those coords are in the new space's
basis, so the marker and wheel got bogus values. Convert to oklch
before destructuring.