### PR TITLE
Add out-of-gamut color mode toggle for OKLCH color picker

### DIFF
--- a/gamut/index.html
+++ b/gamut/index.html
@@ -12,15 +12,13 @@
 	<main>
 		<color-picker space="oklch" :color="pickerColor" @colorchange="onColorChange"></color-picker>
 
-		<fieldset class="oog-mode">
-			<legend>Out of gamut colors</legend>
-			<label><input type="radio" v-model="oogMode" value="dont-paint"> Don't paint</label>
-			<label><input type="radio" v-model="oogMode" value="auto"> Auto</label>
-		</fieldset>
+		<label class="oog-mode">
+			<input type="checkbox" v-model="paintOOG"> Paint out of gamut colors
+		</label>
 
 		<div class="wheel-wrap" ref="wheel"
 			:class="{ dragging }"
-			:data-oog-mode="oogMode"
+			:data-paint-oog="paintOOG"
 			@pointerdown="onPointerDown"
 			@pointermove="onPointerMove"
 			@pointerup="onPointerUp"
@@ -46,7 +44,7 @@
 				'--marker-h': markerH + 'deg',
 			}" aria-hidden="true"></div>
 
-			<div v-if="oogMode === 'auto'" class="boundary" aria-hidden="true"></div>
+			<div v-if="paintOOG" class="boundary" aria-hidden="true"></div>
 
 			<div class="hue-labels" aria-hidden="true">
 				<span style="--angle: 0deg">h=0°</span>

--- a/gamut/index.html
+++ b/gamut/index.html
@@ -13,14 +13,12 @@
 		<div class="controls">
 			<color-picker space="oklch" :color="pickerColor" @colorchange="onColorChange"></color-picker>
 			<div class="meta">
-				<label class="gamut">
+				<div class="gamut">
 					Gamut:
-					<select :value="gamut" @change="gamut = $event.target.value">
-						<option value="srgb">sRGB</option>
-						<option value="p3">P3</option>
-						<option value="rec2020">Rec2020</option>
-					</select>
-				</label>
+					<label><input type="radio" name="gamut" value="srgb" :checked="gamut === 'srgb'" @change="gamut = 'srgb'">sRGB</label>
+					<label><input type="radio" name="gamut" value="p3" :checked="gamut === 'p3'" @change="gamut = 'p3'">P3</label>
+					<label><input type="radio" name="gamut" value="rec2020" :checked="gamut === 'rec2020'" @change="gamut = 'rec2020'">Rec2020</label>
+				</div>
 				<label class="oog-mode">
 					<input type="checkbox" v-model="paintOOG"> Paint out of gamut colors
 				</label>

--- a/gamut/index.html
+++ b/gamut/index.html
@@ -20,6 +20,7 @@
 
 		<div class="wheel-wrap" ref="wheel"
 			:class="{ dragging }"
+			:data-oog-mode="oogMode"
 			@pointerdown="onPointerDown"
 			@pointermove="onPointerMove"
 			@pointerup="onPointerUp"
@@ -28,8 +29,9 @@
 			'--size': cssSize + 'px',
 			'--max-c': maxChroma,
 			'--l': lightness,
+			'--gamut-shape': gamutShape,
 		}">
-			<div class="layers" :style="{ 'clip-path': clipPath }">
+			<div class="layers">
 				<div v-for="layer in layers" :key="layer.idx" class="layer"
 					:style="{ '--c': layer.c }"></div>
 			</div>
@@ -43,6 +45,8 @@
 				'--marker-c': markerC,
 				'--marker-h': markerH + 'deg',
 			}" aria-hidden="true"></div>
+
+			<div v-if="oogMode === 'auto'" class="boundary" aria-hidden="true"></div>
 
 			<div class="hue-labels" aria-hidden="true">
 				<span style="--angle: 0deg">h=0°</span>

--- a/gamut/index.html
+++ b/gamut/index.html
@@ -12,6 +12,12 @@
 	<main>
 		<color-picker space="oklch" :color="pickerColor" @colorchange="onColorChange"></color-picker>
 
+		<fieldset class="oog-mode">
+			<legend>Out of gamut colors</legend>
+			<label><input type="radio" v-model="oogMode" value="dont-paint"> Don't paint</label>
+			<label><input type="radio" v-model="oogMode" value="auto"> Auto</label>
+		</fieldset>
+
 		<div class="wheel-wrap" ref="wheel"
 			:class="{ dragging }"
 			@pointerdown="onPointerDown"

--- a/gamut/index.html
+++ b/gamut/index.html
@@ -12,9 +12,19 @@
 	<main>
 		<div class="controls">
 			<color-picker space="oklch" :color="pickerColor" @colorchange="onColorChange"></color-picker>
-			<label class="oog-mode">
-				<input type="checkbox" v-model="paintOOG"> Paint out of gamut colors
-			</label>
+			<div class="meta">
+				<label class="gamut">
+					Gamut:
+					<select v-model="gamut">
+						<option value="srgb">sRGB</option>
+						<option value="p3">P3</option>
+						<option value="rec2020">Rec2020</option>
+					</select>
+				</label>
+				<label class="oog-mode">
+					<input type="checkbox" v-model="paintOOG"> Paint out of gamut colors
+				</label>
+			</div>
 		</div>
 
 		<div class="wheel-wrap" ref="wheel"

--- a/gamut/index.html
+++ b/gamut/index.html
@@ -10,11 +10,12 @@
 </head>
 <body>
 	<main>
-		<color-picker space="oklch" :color="pickerColor" @colorchange="onColorChange"></color-picker>
-
-		<label class="oog-mode">
-			<input type="checkbox" v-model="paintOOG"> Paint out of gamut colors
-		</label>
+		<div class="controls">
+			<color-picker space="oklch" :color="pickerColor" @colorchange="onColorChange"></color-picker>
+			<label class="oog-mode">
+				<input type="checkbox" v-model="paintOOG"> Paint out of gamut colors
+			</label>
+		</div>
 
 		<div class="wheel-wrap" ref="wheel"
 			:class="{ dragging }"

--- a/gamut/index.html
+++ b/gamut/index.html
@@ -15,7 +15,7 @@
 			<div class="meta">
 				<label class="gamut">
 					Gamut:
-					<select v-model="gamut">
+					<select :value="gamut" @change="gamut = $event.target.value">
 						<option value="srgb">sRGB</option>
 						<option value="p3">P3</option>
 						<option value="rec2020">Rec2020</option>

--- a/gamut/index.js
+++ b/gamut/index.js
@@ -15,9 +15,23 @@ const HUE_BUCKETS = 360;       // 1° resolution for the gamut boundary polygon
 const SEARCH_ITERS = 12;       // binary-search iterations per hue (precision ≈ MAX_CHROMA / 2^12)
 const PROBE_ITERS = 6;         // refine iterations after optimistic walk
 
-// Cache the most recent (L, maxC) so consecutive renders at the same L do no work,
-// and so drag updates can probe outward/inward from the previous L's boundary.
+// Pick the widest gamut the device claims to support. matchMedia("color-gamut: x")
+// matches if the display covers x or wider, so probe from widest to narrowest.
+function detectGamut () {
+	if (matchMedia("(color-gamut: rec2020)").matches) {
+		return "rec2020";
+	}
+	if (matchMedia("(color-gamut: p3)").matches) {
+		return "p3";
+	}
+	return "srgb";
+}
+
+// Cache the most recent (L, gamut, maxC) so consecutive renders at the same L
+// do no work, and so drag updates can probe outward/inward from the previous
+// L's boundary. Changing the target gamut invalidates the cache entirely.
 let cachedL = null;
+let cachedGamut = null;
 let cachedMaxC = null;
 
 globalThis.app = createApp({
@@ -41,8 +55,10 @@ globalThis.app = createApp({
 			dragLockC: 0,
 			dragLockH: 0,
 			// When true, lifts the clip and lets the browser render OOG OKLCH
-			// values natively. When false, the disc is clipped to the P3 polygon.
+			// values natively. When false, the disc is clipped to the gamut polygon.
 			paintOOG: false,
+			// Target gamut for the boundary; defaults to the device's widest support.
+			gamut: detectGamut(),
 		};
 	},
 
@@ -64,11 +80,16 @@ globalThis.app = createApp({
 		 */
 		maxC () {
 			const L = this.lightness;
-			if (cachedL === L && cachedMaxC) {
+			const gamut = this.gamut;
+			if (cachedL === L && cachedGamut === gamut && cachedMaxC) {
 				return cachedMaxC;
 			}
-			const arr = cachedMaxC ? updateMaxC(L, cachedMaxC) : computeMaxC(L);
+			// Reuse the previous boundary as a warm start only when the target gamut
+			// is unchanged; a different gamut wants a fresh full search.
+			const warmStart = cachedMaxC && cachedGamut === gamut;
+			const arr = warmStart ? updateMaxC(L, cachedMaxC, gamut) : computeMaxC(L, gamut);
 			cachedL = L;
+			cachedGamut = gamut;
 			cachedMaxC = arr;
 			return arr;
 		},
@@ -176,8 +197,8 @@ globalThis.app = createApp({
 	},
 }).mount(document.body);
 
-/** Full binary search per hue. Used the first time we see a given L. */
-function computeMaxC (L) {
+/** Full binary search per hue. Used the first time we see a given (L, gamut). */
+function computeMaxC (L, gamut) {
 	const arr = new Float32Array(HUE_BUCKETS);
 	for (let i = 0; i < HUE_BUCKETS; i++) {
 		const h = (i / HUE_BUCKETS) * 360;
@@ -185,7 +206,7 @@ function computeMaxC (L) {
 		let hi = MAX_CHROMA;
 		for (let iter = 0; iter < SEARCH_ITERS; iter++) {
 			const mid = (lo + hi) / 2;
-			if (inGamut({ space: "oklch", coords: [L, mid, h] }, "p3")) {
+			if (inGamut({ space: "oklch", coords: [L, mid, h] }, gamut)) {
 				lo = mid;
 			}
 			else {
@@ -204,7 +225,7 @@ function computeMaxC (L) {
  * a few binary-search iterations. For small ΔL each hue takes ~3–7 inGamut calls
  * instead of SEARCH_ITERS (12).
  */
-function updateMaxC (L, prevMaxC) {
+function updateMaxC (L, prevMaxC, gamut) {
 	const n = prevMaxC.length;
 	const arr = new Float32Array(n);
 
@@ -214,14 +235,14 @@ function updateMaxC (L, prevMaxC) {
 		let lo;
 		let hi;
 
-		const startInGamut = inGamut({ space: "oklch", coords: [L, startC, h] }, "p3");
+		const startInGamut = inGamut({ space: "oklch", coords: [L, startC, h] }, gamut);
 
 		if (startInGamut) {
 			// Boundary is at startC or above. Walk outward.
 			lo = startC;
 			hi = MAX_CHROMA;
 			let step = 0.005;
-			while (lo + step <= MAX_CHROMA && inGamut({ space: "oklch", coords: [L, lo + step, h] }, "p3")) {
+			while (lo + step <= MAX_CHROMA && inGamut({ space: "oklch", coords: [L, lo + step, h] }, gamut)) {
 				lo += step;
 				step *= 2;
 			}
@@ -236,7 +257,7 @@ function updateMaxC (L, prevMaxC) {
 			hi = startC;
 			lo = 0;
 			let step = 0.005;
-			while (hi - step >= 0 && !inGamut({ space: "oklch", coords: [L, hi - step, h] }, "p3")) {
+			while (hi - step >= 0 && !inGamut({ space: "oklch", coords: [L, hi - step, h] }, gamut)) {
 				hi -= step;
 				step *= 2;
 			}
@@ -250,7 +271,7 @@ function updateMaxC (L, prevMaxC) {
 		// Refine the bracket [lo, hi] with binary search.
 		for (let iter = 0; iter < PROBE_ITERS; iter++) {
 			const mid = (lo + hi) / 2;
-			if (inGamut({ space: "oklch", coords: [L, mid, h] }, "p3")) {
+			if (inGamut({ space: "oklch", coords: [L, mid, h] }, gamut)) {
 				lo = mid;
 			}
 			else {

--- a/gamut/index.js
+++ b/gamut/index.js
@@ -40,9 +40,9 @@ globalThis.app = createApp({
 			// when shift/alt is held during the drag.
 			dragLockC: 0,
 			dragLockH: 0,
-			// "dont-paint" clips the disc to the P3 gamut polygon; "auto" lifts
-			// the clip and lets the browser render OOG OKLCH values natively.
-			oogMode: "dont-paint",
+			// When true, lifts the clip and lets the browser render OOG OKLCH
+			// values natively. When false, the disc is clipped to the P3 polygon.
+			paintOOG: false,
 		};
 	},
 

--- a/gamut/index.js
+++ b/gamut/index.js
@@ -91,25 +91,22 @@ globalThis.app = createApp({
 		},
 
 		/**
-		 * The gamut boundary as a CSS `polygon(...)` string in percentage coordinates,
-		 * to be applied as `clip-path` on the layer stack. One vertex per hue bucket;
-		 * the polygon's edges are anti-aliased natively by the browser so the gamut
-		 * boundary stays smooth no matter how coarse our `maxC` sampling is.
+		 * The gamut boundary as a CSS `polygon(...)` string in percentage coordinates.
+		 * One vertex per hue bucket; published as `--gamut-shape` on the wheel so
+		 * both the layer clip and the "auto"-mode boundary overlay can reuse the
+		 * exact same shape via `clip-path: var(--gamut-shape)`.
 		 */
-		clipPath () {
-			if (this.oogMode === "auto") {
-				return "none";
-			}
+		gamutShape () {
 			const maxC = this.maxC;
 			const n = maxC.length;
-			const points = [];
+			const points = new Array(n);
 			for (let i = 0; i < n; i++) {
 				const h = (i / n) * 360;
 				const r = maxC[i] / MAX_CHROMA;
 				const hRad = (h * Math.PI) / 180;
 				const x = 50 + r * 50 * Math.cos(hRad);
 				const y = 50 - r * 50 * Math.sin(hRad); // screen y is flipped
-				points.push(`${x.toFixed(2)}% ${y.toFixed(2)}%`);
+				points[i] = `${x.toFixed(2)}% ${y.toFixed(2)}%`;
 			}
 			return `polygon(${points.join(", ")})`;
 		},

--- a/gamut/index.js
+++ b/gamut/index.js
@@ -40,6 +40,9 @@ globalThis.app = createApp({
 			// when shift/alt is held during the drag.
 			dragLockC: 0,
 			dragLockH: 0,
+			// "dont-paint" clips the disc to the P3 gamut polygon; "auto" lifts
+			// the clip and lets the browser render OOG OKLCH values natively.
+			oogMode: "dont-paint",
 		};
 	},
 
@@ -94,6 +97,9 @@ globalThis.app = createApp({
 		 * boundary stays smooth no matter how coarse our `maxC` sampling is.
 		 */
 		clipPath () {
+			if (this.oogMode === "auto") {
+				return "none";
+			}
 			const maxC = this.maxC;
 			const n = maxC.length;
 			const points = [];

--- a/gamut/style.css
+++ b/gamut/style.css
@@ -191,8 +191,10 @@ color-picker {
 		}
 
 		&:has(:checked) {
+			/* iOS Safari resolves AccentColorText to black, so force white for
+			   contrast on the system blue / accent fill. */
 			background: AccentColor;
-			color: AccentColorText;
+			color: white;
 			border-color: AccentColor;
 		}
 

--- a/gamut/style.css
+++ b/gamut/style.css
@@ -49,7 +49,7 @@ color-picker {
 		clip-path: var(--gamut-shape);
 	}
 
-	&[data-oog-mode="auto"] .layers {
+	&[data-paint-oog="true"] .layers {
 		clip-path: none;
 	}
 
@@ -155,23 +155,9 @@ color-picker {
 }
 
 .oog-mode {
-	border: 1px solid color-mix(in oklch, currentColor, transparent 80%);
-	border-radius: 0.4em;
-	padding: 0.4em 0.8em 0.6em;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4em;
 	font-size: 0.9em;
-	display: flex;
-	flex-wrap: wrap;
-	gap: 0.4em 1em;
-
-	legend {
-		padding-inline: 0.4em;
-		color: color-mix(in oklch, currentColor, transparent 30%);
-	}
-
-	label {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.3em;
-		cursor: pointer;
-	}
+	cursor: pointer;
 }

--- a/gamut/style.css
+++ b/gamut/style.css
@@ -157,12 +157,18 @@ color-picker {
 	}
 }
 
-.oog-mode {
-	display: inline-flex;
+.meta {
+	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
-	gap: 0.3em;
+	gap: 0.4em 1em;
 	font-size: 0.8em;
 	color: color-mix(in oklch, currentColor, transparent 30%);
-	cursor: pointer;
-	align-self: start;
+
+	label {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3em;
+		cursor: pointer;
+	}
 }

--- a/gamut/style.css
+++ b/gamut/style.css
@@ -130,3 +130,25 @@ color-picker {
 		span:nth-child(odd) { display: none; }
 	}
 }
+
+.oog-mode {
+	border: 1px solid color-mix(in oklch, currentColor, transparent 80%);
+	border-radius: 0.4em;
+	padding: 0.4em 0.8em 0.6em;
+	font-size: 0.9em;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.4em 1em;
+
+	legend {
+		padding-inline: 0.4em;
+		color: color-mix(in oklch, currentColor, transparent 30%);
+	}
+
+	label {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3em;
+		cursor: pointer;
+	}
+}

--- a/gamut/style.css
+++ b/gamut/style.css
@@ -14,7 +14,7 @@ main {
 }
 
 .controls {
-	flex: 0 1 auto;
+	flex: 1;
 	min-width: 0;
 	display: flex;
 	flex-direction: column;

--- a/gamut/style.css
+++ b/gamut/style.css
@@ -16,6 +16,9 @@ main {
 .controls {
 	flex: 0 1 auto;
 	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.6em;
 }
 
 color-picker {
@@ -157,7 +160,9 @@ color-picker {
 .oog-mode {
 	display: inline-flex;
 	align-items: center;
-	gap: 0.4em;
-	font-size: 0.9em;
+	gap: 0.3em;
+	font-size: 0.8em;
+	color: color-mix(in oklch, currentColor, transparent 30%);
 	cursor: pointer;
+	align-self: start;
 }

--- a/gamut/style.css
+++ b/gamut/style.css
@@ -191,9 +191,9 @@ color-picker {
 		}
 
 		&:has(:checked) {
-			background: color-mix(in oklch, currentColor, transparent 85%);
-			border-color: color-mix(in oklch, currentColor, transparent 50%);
-			color: color-mix(in oklch, currentColor, transparent 0%);
+			background: AccentColor;
+			color: AccentColorText;
+			border-color: AccentColor;
 		}
 
 		&:has(:focus-visible) {

--- a/gamut/style.css
+++ b/gamut/style.css
@@ -172,3 +172,33 @@ color-picker {
 		cursor: pointer;
 	}
 }
+
+.gamut {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25em;
+
+	label {
+		padding: 0.1em 0.45em;
+		border-radius: 0.25em;
+		border: 1px solid color-mix(in oklch, currentColor, transparent 80%);
+
+		input {
+			/* radio is the source of truth; hide it visually but keep it focusable */
+			position: absolute;
+			opacity: 0;
+			pointer-events: none;
+		}
+
+		&:has(:checked) {
+			background: color-mix(in oklch, currentColor, transparent 85%);
+			border-color: color-mix(in oklch, currentColor, transparent 50%);
+			color: color-mix(in oklch, currentColor, transparent 0%);
+		}
+
+		&:has(:focus-visible) {
+			outline: 2px solid Highlight;
+			outline-offset: 1px;
+		}
+	}
+}

--- a/gamut/style.css
+++ b/gamut/style.css
@@ -46,7 +46,11 @@ color-picker {
 	.layers {
 		position: absolute;
 		inset: 0;
-		/* clip-path applied inline as a polygon traced from the per-L gamut boundary. */
+		clip-path: var(--gamut-shape);
+	}
+
+	&[data-oog-mode="auto"] .layers {
+		clip-path: none;
 	}
 
 	.layer {
@@ -106,6 +110,25 @@ color-picker {
 		translate:
 			calc(var(--r) * cos(var(--marker-h)))
 			calc(var(--r) * sin(var(--marker-h)) * -1);
+	}
+
+	.boundary {
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		background: white;
+		clip-path: var(--gamut-shape);
+		mix-blend-mode: difference;
+
+		&::after {
+			content: "";
+			position: absolute;
+			inset: 0;
+			background: black;
+			clip-path: var(--gamut-shape);
+			transform: scale(0.99);
+			transform-origin: center;
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR adds an "out-of-gamut (OOG) color mode" toggle to the color picker, allowing users to choose between two rendering strategies for colors outside the Display P3 gamut: clipping to the gamut boundary or rendering native OKLCH values.

## Key Changes

- **New UI Control**: Added a fieldset with radio buttons to toggle between "Don't paint" (clips to P3 gamut) and "Auto" (renders OOG OKLCH natively) modes
- **Refactored Gamut Shape**: Renamed `clipPath()` computed property to `gamutShape()` and published it as a CSS custom property (`--gamut-shape`) for reuse across multiple elements
- **Dynamic Clipping**: The `.layers` element now uses the CSS variable for clipping, with an additional rule to disable clipping when in "auto" mode
- **Boundary Visualization**: Added a new `.boundary` element that renders a visual indicator of the gamut boundary when in "auto" mode using `mix-blend-mode: difference` and a scaled pseudo-element for contrast
- **State Management**: Added `oogMode` data property to track the selected rendering mode and bind it to the radio input and wheel element via `data-oog-mode` attribute

## Implementation Details

- The gamut shape polygon is now computed once and reused via CSS custom property, eliminating duplication and ensuring consistency
- The boundary overlay uses a clever technique with `mix-blend-mode: difference` and a scaled inner pseudo-element to create a visible edge indicator
- The "auto" mode removes the clip-path constraint, allowing the browser to natively render OKLCH colors that fall outside the P3 gamut
- Array pre-allocation optimization in `gamutShape()` for better performance

https://claude.ai/code/session_01XC7iiMi3xrNSTZvx3Di2zS