### PR TITLE
More fair comparison between algorithms

### DIFF
--- a/gamut-mapping/methods.js
+++ b/gamut-mapping/methods.js
@@ -39,11 +39,13 @@ const MAX_CHROMA = 0.4;
 // result is still out of gamut. A method that returns an out-of-gamut color
 // implicitly consents to this clip; it keeps the reported deltas honest, since
 // they're measured against the color the browser can actually display rather
-// than an out-of-gamut value the swatch would silently clip.
+// than an out-of-gamut value the swatch would silently clip. Additionally,
+// ensure all colors are normalized such that the return space matches the input space.
 function normalize (compute) {
 	return (color) => {
+		let space = color.space;
 		let input = color.to("oklch").set({ c: c => Math.min(c, MAX_CHROMA) });
-		let result = compute(input);
+		let result = compute(input).to(space);
 		return result.inGamut("p3") ? result : clipToGamut(result);
 	};
 }

--- a/gamut-mapping/methods/oklch-cubic.js
+++ b/gamut-mapping/methods/oklch-cubic.js
@@ -124,6 +124,13 @@ export function compute (color) {
 	color = color.to("oklch");
 	let [L, C, H] = color.coords;
 
+	if (L >= 1) {
+		return new Color({ space: "oklch", coords: [1, 0, 0] });
+	}
+	else if (L <= 0) {
+		return new Color({ space: "oklch", coords: [0, 0, 0] });
+	}
+
 	// Achromatic (or NaN chroma) is always in gamut: nothing to reduce.
 	if (!(C > 0)) {
 		return color;


### PR DESCRIPTION
Ensure that every gamut mapping method returns the color in the origin space consistently for comparison.

Also, ensure that oklch-cubic checks lightness when gamut mapping.