### PR TITLE
Add URL parameter support for initial color selection

### DIFF
--- a/tints/index.html
+++ b/tints/index.html
@@ -11,7 +11,7 @@
 <body>
 	<section id="params">
 	<label><input type="checkbox" switch v-model="darkMode"> Dark mode</label>
-	<color-picker ref="input" id="input" gamut="p3" space="oklch" color="oklch(70% 0.16 205)" @colorchange="onColorChange"></color-picker>
+	<color-picker ref="input" id="input" gamut="p3" space="oklch" :color="initialColor" @colorchange="onColorChange"></color-picker>
 	<div class="swatches">
 		<button v-for="(value, name) in swatches" :key="name" :style="{ '--swatch': value }" :title="name" @click="pickSwatch(value)"></button>
 	</div>

--- a/tints/index.js
+++ b/tints/index.js
@@ -78,9 +78,15 @@ const scaleDefs = {
 
 };
 
+const params = new URLSearchParams(location.search);
+
+// Set the base color via ?color=… (e.g. ?color=oklch(70% 0.16 205)), falling back
+// to the picker's default when absent. Any CSS color the picker understands works.
+const initialColor = params.get("color") || "oklch(70% 0.16 205)";
+
 // Restrict the visible scales via ?scales=id1,id2 (e.g. for demos or sharing).
 // Unknown ids are ignored; the URL order also defines display order.
-let only = new URLSearchParams(location.search).get("scales");
+let only = params.get("scales");
 const scales = only
 	? Object.fromEntries(
 		only.split(",")
@@ -100,6 +106,7 @@ globalThis.app = createApp({
 	data () {
 		return {
 			swatches,
+			initialColor,
 			color: null,
 			darkMode: false,
 			// Maps each selected scale id to its weight (0–100). Weights always sum to 100.


### PR DESCRIPTION
## Summary
This change adds support for setting the initial color via a URL query parameter (`?color=…`), allowing users to share links with pre-selected colors while maintaining backward compatibility with the existing default.

## Key Changes
- Added `?color=…` URL parameter support to initialize the color picker with a custom color value
  - Falls back to the default `oklch(70% 0.16 205)` when the parameter is absent
  - Accepts any CSS color format that the color picker understands
- Refactored URL parameter parsing to reuse a single `URLSearchParams` instance for both `color` and `scales` parameters
- Updated the color picker binding to use the dynamic `initialColor` data property instead of a hardcoded default value

## Implementation Details
- The `initialColor` is computed once during initialization from the URL parameters and stored in the component's data
- The color picker's `:color` binding is now reactive, allowing the initial color to be set from the URL while still supporting user interaction
- URL parameter parsing is now more efficient, creating a single `URLSearchParams` object that serves both the color and scales parameters

https://claude.ai/code/session_01Wru1XWj2vmrEDsSKEXT23D