### PR TITLE
[gradients] Add hue interpolation method selector

### DIFF
--- a/gradients/index.html
+++ b/gradients/index.html
@@ -51,6 +51,9 @@
 		<details open>
 			<summary>
 				<span property="space" mv-edit="#space" mv-default="lch"></span> interpolation,
+				<span mv-if="hasHue(space)">
+					<span property="hueInterpolation" mv-edit="#hue" mv-default="shorter"></span> hue,
+				</span>
 				<label><input type="number" property="numSteps" value="10" min="2" /> steps</label>
 				<input type="number" property="delta" value="" min="0" /> max ΔE
 				<em>(<span property="stepCount">[count(step)]</span> resulting steps)</em>
@@ -58,7 +61,7 @@
 
 			<div>
 				Colors:
-				<div mv-value="colorSteps(color1.steps(color2, group(steps: numSteps, maxDeltaE: delta, deltaEMethod: '2000', space: space, outputSpace: space)), outputSpace, gamutMapping)" mv-multiple="step" style="--color: [outputColor & ''];">
+				<div mv-value="colorSteps(color1.steps(color2, group(steps: numSteps, maxDeltaE: delta, deltaEMethod: '2000', space: space, outputSpace: space, hue: hueInterpolation)), outputSpace, gamutMapping)" mv-multiple="step" style="--color: [outputColor & ''];">
 					<code>[color & ""]</code> &rarr; <code>[outputColor & ""]</code>
 					<meta property="color" />
 					<meta property="outputColor" content="[color.to(outputSpace)]" />
@@ -80,6 +83,13 @@
 	<select id="space">
 		<option mv-value="ColorSpaces" mv-multiple="colorSpace" mv-group value="[colorSpace.id]">[colorSpace.name]</option>
 	</select>
+
+	<select id="hue">
+		<option value="shorter">shorter</option>
+		<option value="longer">longer</option>
+		<option value="increasing">increasing</option>
+		<option value="decreasing">decreasing</option>
+	</select>
 </div>
 <script type="module">
 	import Color from "colorjs.io";
@@ -87,6 +97,18 @@
 	window.ColorSpaces = Object.values(Color.spaces).map(s => {
 		return {id: s.id, name: s.name}
 	});
+
+	// The hue arc only has an effect in spaces with a hue coordinate,
+	// which is exactly the condition Color.js uses to apply the `hue` option.
+	window.hasHue = function (spaceId) {
+		try {
+			return Boolean(Color.Space.get(Mavo.value(spaceId)).hueId);
+		}
+		catch (e) {
+			// Space not resolved yet, e.g. during the initial render
+			return false;
+		}
+	}
 
 	// Map steps to objects with a color property
 	// because Mavo fiddles with object data

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 	},
 	"dependencies": {
 		"color-elements": "^0.0.14",
-		"colorjs.io": "^0.7.0-alpha.2",
+		"colorjs.io": "^0.7.0",
 		"incrementable": "^2.0.0",
 		"vue": "^3"
 	},


### PR DESCRIPTION
The gradients app generates gradients according to the CSS Color 4 interpolation rules, but offered no way to pick the **hue interpolation method** — it always used the default `shorter` arc.

This adds a per-gradient hue arc control offering the four CSS Color 4 methods: `shorter`, `longer`, `increasing`, `decreasing`. The selected value is passed to Color.js as the `hue` option of `steps()`, which forwards unrecognized options through to `range()`.

The control is rendered only for spaces that actually have a hue coordinate (lch, oklch, hsl, hwb, …) and hidden for the rest (lab, srgb, …), where the arc would have no effect. That gate is keyed on `Space#hueId`, matching the exact condition Color.js uses internally to decide whether to apply the option.

Defaults to `shorter`, so existing gradients are unchanged. Because the control is per-gradient rather than global, you can add a second gradient and compare two arcs side by side.

## Blocked on 0.7.0

`Space#hueId` ships in colorjs.io **0.7.0**, which is not published yet — the newest on the registry is `0.7.0-alpha.2`. `package.json` is therefore bumped to `^0.7.0`, and **`npm install` will not resolve until that release lands**. Do not merge before then; CI install may fail until it does.

## Not yet verified

The app could not be loaded in a browser, for the same reason. Worth a click-through once 0.7.0 is out:
- the control appears/disappears cleanly when a gradient switches between `lch` and `lab`
- a `longer` arc visibly takes the long way round the hue circle

🤖 Generated with [Claude Code](https://claude.com/claude-code)