### PR TITLE
Fix color favicon and show clipped + gamut-mapped hex

### DIFF
--- a/convert/convert.js
+++ b/convert/convert.js
@@ -26,6 +26,7 @@ function renderSpace(space, format, color) {
 		? converted.clone().toGamut({method: "clip"}).toString({precision, format})
 		: converted.toString({precision, inGamut: false, format});
 	let str_mapped = converted.toString({precision, inGamut: true, format});
+	let clipped = format === "hex" && str !== str_mapped;
 	let permalink = `?color=${encodeURIComponent(str)}&precision=${encodeURIComponent(precision)}`;
 	let permalink_mapped = `?color=${encodeURIComponent(str_mapped)}&precision=${encodeURIComponent(precision)}`;
 
@@ -34,7 +35,7 @@ function renderSpace(space, format, color) {
 		<th>${space.name}${ format ? ` (${format})` : '' }</th>
 		<td>${converted.coords.join(", ")}</td>
 		<td>
-			<div class="serialization ${inGamut || str === str_mapped ? "in-gamut" : "out-of-gamut"} ${!inGamut && str === str_mapped ? "gamut-mapped" : ""}">
+			<div class="serialization ${inGamut || str === str_mapped ? "in-gamut" : "out-of-gamut"} ${!inGamut && str === str_mapped ? "gamut-mapped" : ""} ${clipped ? "clipped" : ""}">
 				<a href="${permalink}" ${!inGamut ? 'title="Out of gamut"' : ""}>${str}</a>
 				<button class="copy" data-clipboard-text="${str}" title="Copy">📋</button>
 			</div>

--- a/convert/convert.js
+++ b/convert/convert.js
@@ -17,9 +17,11 @@ function renderSpace(space, format, color) {
 	}
 
 	let precision = precisionInput.value;
+	let gamutMapping = gamutMappingInput.checked;
 	let inGamut = converted.inGamut();
 	let str = converted.toString({precision, inGamut: false, format});
 	let str_mapped = converted.toString({precision, inGamut: true, format});
+	let showMapped = gamutMapping && str !== str_mapped;
 	let permalink = `?color=${encodeURIComponent(str)}&precision=${encodeURIComponent(precision)}`;
 	let permalink_mapped = `?color=${encodeURIComponent(str_mapped)}&precision=${encodeURIComponent(precision)}`;
 
@@ -32,7 +34,7 @@ function renderSpace(space, format, color) {
 				<a href="${permalink}" ${!inGamut ? 'title="Out of gamut"' : ""}>${str}</a>
 				<button class="copy" data-clipboard-text="${str}" title="Copy">📋</button>
 			</div>
-			${str !== str_mapped ? `
+			${showMapped ? `
 			<div class="serialization gamut-mapped">
 				<a href="${permalink_mapped}">${str_mapped}</a>
 				<button class="copy" data-clipboard-text="${str_mapped}" title="Copy">📋</button>
@@ -97,6 +99,7 @@ let urlParams = getURLParams();
 
 colorInput.addEventListener("input", update);
 precisionInput.addEventListener("input", update);
+gamutMappingInput.addEventListener("input", update);
 
 function updateFromURL () {
 	colorInput.value = urlParams.color || colorInput.value;

--- a/convert/convert.js
+++ b/convert/convert.js
@@ -13,15 +13,19 @@ function renderSpace(space, format, color) {
 
 	if (id === "srgb" || (id === "p3") && supportsP3) {
 		colorOutput.style.background = converted;
-		favicon.href = `data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"><rect width="100%" fill="${converted}" /></svg>`;
+		let svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><rect width="16" height="16" fill="${converted}" /></svg>`;
+		favicon.href = `data:image/svg+xml,${encodeURIComponent(svg)}`;
 	}
 
 	let precision = precisionInput.value;
-	let gamutMapping = gamutMappingInput.checked;
 	let inGamut = converted.inGamut();
-	let str = converted.toString({precision, inGamut: false, format});
+	// Hex can only represent sRGB, so toString({format: "hex"}) always gamut-maps
+	// out-of-gamut colors. Use a naive clip for the raw value so hex shows both a
+	// clipped and a gamut-mapped serialization, like every other format.
+	let str = format === "hex"
+		? converted.clone().toGamut({method: "clip"}).toString({precision, format})
+		: converted.toString({precision, inGamut: false, format});
 	let str_mapped = converted.toString({precision, inGamut: true, format});
-	let showMapped = gamutMapping && str !== str_mapped;
 	let permalink = `?color=${encodeURIComponent(str)}&precision=${encodeURIComponent(precision)}`;
 	let permalink_mapped = `?color=${encodeURIComponent(str_mapped)}&precision=${encodeURIComponent(precision)}`;
 
@@ -34,7 +38,7 @@ function renderSpace(space, format, color) {
 				<a href="${permalink}" ${!inGamut ? 'title="Out of gamut"' : ""}>${str}</a>
 				<button class="copy" data-clipboard-text="${str}" title="Copy">📋</button>
 			</div>
-			${showMapped ? `
+			${str !== str_mapped ? `
 			<div class="serialization gamut-mapped">
 				<a href="${permalink_mapped}">${str_mapped}</a>
 				<button class="copy" data-clipboard-text="${str_mapped}" title="Copy">📋</button>
@@ -99,7 +103,6 @@ let urlParams = getURLParams();
 
 colorInput.addEventListener("input", update);
 precisionInput.addEventListener("input", update);
-gamutMappingInput.addEventListener("input", update);
 
 function updateFromURL () {
 	colorInput.value = urlParams.color || colorInput.value;

--- a/convert/index.html
+++ b/convert/index.html
@@ -19,6 +19,11 @@
 	<label>
 		Precision: <input type="number" id="precisionInput" value="4" max="21">
 	</label>
+
+	<label class="gamut-mapping-toggle">
+		<input type="checkbox" id="gamutMappingInput" checked>
+		Gamut mapping
+	</label>
 </div>
 
 <table id="output">

--- a/convert/index.html
+++ b/convert/index.html
@@ -19,11 +19,6 @@
 	<label>
 		Precision: <input type="number" id="precisionInput" value="4" max="21">
 	</label>
-
-	<label class="gamut-mapping-toggle">
-		<input type="checkbox" id="gamutMappingInput" checked>
-		Gamut mapping
-	</label>
 </div>
 
 <table id="output">

--- a/convert/style.css
+++ b/convert/style.css
@@ -37,18 +37,6 @@ input:is(
 		display: block;
 	}
 
-	.inputs .gamut-mapping-toggle {
-		grid-column: 1 / -1;
-		display: flex;
-		align-items: center;
-		gap: .4em;
-	}
-
-		.inputs .gamut-mapping-toggle input {
-			display: inline-block;
-			width: auto;
-		}
-
 table {
 	width: 100%;
 	display: grid;

--- a/convert/style.css
+++ b/convert/style.css
@@ -37,6 +37,18 @@ input:is(
 		display: block;
 	}
 
+	.inputs .gamut-mapping-toggle {
+		grid-column: 1 / -1;
+		display: flex;
+		align-items: center;
+		gap: .4em;
+	}
+
+		.inputs .gamut-mapping-toggle input {
+			display: inline-block;
+			width: auto;
+		}
+
 table {
 	width: 100%;
 	display: grid;

--- a/convert/style.css
+++ b/convert/style.css
@@ -100,16 +100,25 @@ tbody th {
 		color: hsl(0 90% 38%);
 	}
 
-	&.gamut-mapped::after {
-		content: "Gamut\amapped";
+	&.gamut-mapped::after,
+	&.clipped::after {
 		display: inline-block;
 		font: bold 9px/1 var(--font-ui);
-		background: hsl(0 40% 50% / .15);
 		text-transform: uppercase;
 		white-space: pre-line;
 		padding: .4em .6em;
 		border-radius: .3em;
 		margin: auto 0 auto .5em;
+	}
+
+	&.gamut-mapped::after {
+		content: "Gamut\amapped";
+		background: hsl(0 40% 50% / .15);
+	}
+
+	&.clipped::after {
+		content: "Clipped";
+		background: hsl(35 60% 50% / .2);
 	}
 
 	& button {


### PR DESCRIPTION
## Summary
Fixes the color favicon in the convert app and makes the hex output show both a clipped and a gamut-mapped value, like every other format.

## Key Changes
- **Favicon**: The color favicon stopped rendering because Color.js now serializes sRGB with percentages (e.g. `rgb(0% 100% 0%)`); the unencoded `data:` URI treated the `%` signs as malformed percent-escapes. The SVG is now `encodeURIComponent`-encoded and given explicit dimensions.
- **Hex**: Hex can only represent the sRGB gamut, so `toString({format: "hex"})` always gamut-maps out-of-gamut colors — meaning hex only ever showed a single value. The raw hex now uses a naive clip, so an out-of-gamut color displays both a clipped and a gamut-mapped serialization.
- **"Clipped" badge**: The clipped hex value is labelled with a "Clipped" badge, mirroring the existing "Gamut mapped" badge (shared badge styling factored out).

## Notes
The unrelated "Redirect rules" check failure is pre-existing on `main` (an external `htest.dev` proxy rule in `_redirects` without a status code) and is not affected by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)