### PR TITLE
Add Oklab vs. Oklrab interpolation comparison app

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ They are useful in their own right, but also serve as [Color.js](https://colorjs
 	- [Gamut Mapping Gradients](gamut-mapping-gradients)
 - [Gamut Wheel](gamut)
 - [Tints](tints)
+- [Oklab vs. Oklrab interpolation](lr-vs-l)
 
 ## External
 

--- a/lr-vs-l/README.md
+++ b/lr-vs-l/README.md
@@ -1,0 +1,3 @@
+# Oklab vs. Oklrab interpolation
+
+This app compares interpolation in Oklab with interpolation in Oklrab. Choose two colors and two gradients are displayed. Toggle the background from white to black. Oklab assumes no primary adaptive white, while Oklrab has a "toe" that predicts lightness better against a white background.

--- a/lr-vs-l/index.html
+++ b/lr-vs-l/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Oklab vs. Oklrab interpolation</title>
+<link rel="stylesheet" href="style.css">
+
+</head>
+<body>
+
+<h1>Oklab vs. Oklrab interpolation</h1>
+
+<p class="intro">
+	Oklab assumes no primary adaptive white, while Oklrab has a “toe” that predicts lightness
+	better against a white background. Pick two colors to compare how each space interpolates
+	between them, and toggle the page background to see how that changes.
+</p>
+
+<div class="inputs">
+	<label>
+		Color 1:
+		<input type="text" id="color1" value="navy">
+	</label>
+
+	<label>
+		Color 2:
+		<input type="text" id="color2" value="gold">
+	</label>
+
+	<label class="bg-toggle">
+		<input type="checkbox" id="bgToggle">
+		Black background
+	</label>
+
+	<a id="permalink" href="">Permalink</a>
+</div>
+
+<div class="stage">
+	<figure>
+		<figcaption>Oklab</figcaption>
+		<div class="gradient" id="gradientOklab"></div>
+	</figure>
+
+	<figure>
+		<figcaption>Oklrab</figcaption>
+		<div class="gradient" id="gradientOklrab"></div>
+	</figure>
+</div>
+
+<script src="../importmap.js"></script>
+<script type="module" src="index.js"></script>
+</body>
+</html>

--- a/lr-vs-l/index.js
+++ b/lr-vs-l/index.js
@@ -1,0 +1,67 @@
+import Color from "colorjs.io";
+
+const STEPS = 128;
+
+function getURLParams () {
+	return Object.fromEntries(new URL(location).searchParams);
+}
+
+function getColor (str) {
+	try {
+		return new Color(str);
+	}
+	catch (e) {
+		return null;
+	}
+}
+
+function renderGradient (el, c1, c2, space) {
+	let colors = c1.steps(c2, {space, outputSpace: "srgb", steps: STEPS});
+	let stops = colors.map((c, i) => `${c.toString({precision: 3})} ${(i / (colors.length - 1) * 100).toFixed(2)}%`);
+	el.style.background = `linear-gradient(to right, ${stops.join(", ")})`;
+}
+
+function update () {
+	let c1 = getColor(color1.value);
+	let c2 = getColor(color2.value);
+
+	color1.setCustomValidity(c1 ? "" : "Cannot parse color");
+	color2.setCustomValidity(c2 ? "" : "Cannot parse color");
+	color1.style.setProperty("--color", c1 ? c1.toString({precision: 3}) : "");
+	color2.style.setProperty("--color", c2 ? c2.toString({precision: 3}) : "");
+
+	if (!c1 || !c2) {
+		return;
+	}
+
+	renderGradient(gradientOklab, c1, c2, "oklab");
+	renderGradient(gradientOklrab, c1, c2, "oklrab");
+
+	let query = `?color1=${encodeURIComponent(color1.value)}&color2=${encodeURIComponent(color2.value)}`;
+	history.replaceState(null, "", query);
+	permalink.href = query;
+}
+
+function updateBg () {
+	document.body.classList.toggle("bg-black", bgToggle.checked);
+}
+
+document.body.addEventListener("input", evt => {
+	if (evt.target === bgToggle) {
+		updateBg();
+	}
+	else {
+		update();
+	}
+});
+
+let params = getURLParams();
+if (params.color1) {
+	color1.value = params.color1;
+}
+if (params.color2) {
+	color2.value = params.color2;
+}
+
+update();
+updateBg();

--- a/lr-vs-l/style.css
+++ b/lr-vs-l/style.css
@@ -1,0 +1,83 @@
+:root {
+	--font-ui: system-ui, Helvetica Neue, Helvetica, Segoe UI, sans-serif;
+}
+
+body {
+	font: 120%/1.5 var(--font-ui);
+	width: 90vw;
+	max-width: 60em;
+	margin: 1em auto;
+	padding: 0 2em;
+	transition: background .2s ease, color .2s ease;
+}
+
+body.bg-black {
+	background: black;
+	color: white;
+}
+
+h1 {
+	text-align: center;
+}
+
+.intro {
+	max-width: 42em;
+	margin: 0 auto 2em;
+	text-align: center;
+	opacity: .8;
+}
+
+.inputs {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: center;
+	gap: 1.5em;
+	margin-bottom: 2em;
+}
+
+.inputs label {
+	display: flex;
+	align-items: center;
+	gap: .5em;
+}
+
+.inputs input[type="text"] {
+	font: inherit;
+	font-size: 100%;
+	padding: .3em .6em;
+	border: 3px solid var(--color, silver);
+	border-radius: .3em;
+	background: hsl(0 0% 100% / .8);
+	color: black;
+}
+
+.inputs input:invalid {
+	border-color: hsl(0 90% 45%);
+}
+
+.bg-toggle {
+	cursor: pointer;
+}
+
+.stage {
+	display: grid;
+	gap: 2em;
+	padding: 2em;
+	border-radius: .5em;
+}
+
+figure {
+	margin: 0;
+}
+
+figcaption {
+	font-weight: bold;
+	margin-bottom: .5em;
+}
+
+.gradient {
+	height: 4em;
+	border-radius: .3em;
+	box-shadow: 0 0 0 1px hsl(0 0% 50% / .3);
+}


### PR DESCRIPTION
## Summary
- New `lr-vs-l/` app: pick two colors and see them interpolated in Oklab vs. Oklrab side by side, with a black/white background toggle to demonstrate Oklrab's lightness "toe" (Oklab assumes no primary adaptive white; Oklrab predicts lightness better against a white background).
- Plain JS + `colorjs.io` module, matching the newer `convert`/`gamut-mapping` app style rather than the Mavo-based `gradients` app.
- Adds a README specifying this app, and linked the new app from the top-level README under Research Apps.

## Test plan
- [x] Loaded the page in headless Chromium (Playwright) with console error checking — none.
- [x] Verified the two gradients visibly diverge for colors with a large lightness gap (e.g. navy→gold, black→white), consistent with Oklrab's toe.
- [x] Verified live updates on color input change and the background toggle.
- [x] Bumped interpolation steps 32 → 128 after spotting visible banding in manual browser testing.
- [ ] Not yet checked against the production build pipeline (`npx nudeps` fails locally on Windows with an unrelated symlink permission error — tested instead via a temporary local import map, removed before committing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)