### PR TITLE
Add color-mix() step-by-step app

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ They are useful in their own right, but also serve as [Color.js](https://colorjs
 - [Convert across everything](convert)
 - [Black or white?](blackwhite)
 - [Gradient interpolation](gradients)
+- [color-mix() step by step](color-mix)
 - [Named color proximity](named)
 
 ## Research Apps

--- a/color-mix/README.md
+++ b/color-mix/README.md
@@ -1,0 +1,7 @@
+# color-mix() step by step
+
+This app demonstrates the CSS Color 5 [`color-mix()`](https://www.w3.org/TR/css-color-5/#color-mix) function. Type any legal `color-mix()` value and it is parsed, showing the mixing color space and hue interpolation method, every color both in its own color space and in the mixing color space, and each stage of [the color-mix() algorithm](https://www.w3.org/TR/css-color-5/#color-mix-result): percentage normalization, conversion to the mixing color space, carrying missing components forward, hue fix-up, premultiplication, interpolation, un-premultiplication, and the final alpha multiplier.
+
+The result is also compared with the one your browser computes for the same value.
+
+The mixing is implemented from the specification in [`colormix.js`](colormix.js) rather than being delegated to Color.js, so that every intermediate value can be shown. Color.js does the color parsing and the color space conversions.

--- a/color-mix/colormix.js
+++ b/color-mix/colormix.js
@@ -245,7 +245,8 @@ function parseMixItem (str, index) {
  * color-mix() = color-mix( <color-interpolation-method>? , [ <color> && <percentage [0,100]>? ]# )
  */
 export function parseColorMix (input) {
-	let str = String(input).trim();
+	// Tolerate a trailing semicolon, which comes along easily when pasting from a stylesheet
+	let str = String(input).trim().replace(/;+$/, "").trim();
 	let match = str.match(/^color-mix\s*\(([\s\S]*)\)$/i);
 
 	if (!match || !balanced(match[1])) {

--- a/color-mix/colormix.js
+++ b/color-mix/colormix.js
@@ -1,0 +1,589 @@
+/**
+ * A traced implementation of CSS Color 5 color-mix(),
+ * following https://www.w3.org/TR/css-color-5/#color-mix-result
+ * step by step so that every intermediate value can be displayed.
+ *
+ * Color.js is used for parsing colors and for color space conversion,
+ * but the mixing itself is spelled out here rather than delegated to
+ * Color.js' own interpolation, so that each stage can be inspected.
+ */
+import Color from "colorjs.io";
+
+/** CSS <color-space> keywords, mapped to Color.js space ids */
+export const SPACES = {
+	"srgb": "srgb",
+	"srgb-linear": "srgb-linear",
+	"display-p3": "p3",
+	"display-p3-linear": "p3-linear",
+	"a98-rgb": "a98rgb",
+	"prophoto-rgb": "prophoto",
+	"rec2020": "rec2020",
+	"lab": "lab",
+	"oklab": "oklab",
+	"xyz": "xyz-d65",
+	"xyz-d50": "xyz-d50",
+	"xyz-d65": "xyz-d65",
+	"hsl": "hsl",
+	"hwb": "hwb",
+	"lch": "lch",
+	"oklch": "oklch",
+};
+
+/** <polar-color-space>; everything else in SPACES is a <rectangular-color-space> */
+export const POLAR_SPACES = ["hsl", "hwb", "lch", "oklch"];
+
+/** <hue-interpolation-method> */
+export const HUE_METHODS = ["shorter", "longer", "increasing", "decreasing"];
+
+/** If no <color-interpolation-method> is given, CSS Color 5 3.1 says to assume Oklab */
+export const DEFAULT_SPACE = "oklab";
+
+/**
+ * Analogous components, CSS Color 4 13.3.
+ * Keyed by the component names Color.js uses, which are distinct across spaces
+ * (HWB's "Blackness" is deliberately not the same as sRGB's "Blue").
+ * Whiteness and Blackness have no analogs, so they are absent here.
+ */
+const ANALOGOUS = {
+	"Red": "Reds",
+	"X": "Reds",
+	"Green": "Greens",
+	"Y": "Greens",
+	"Blue": "Blues",
+	"Z": "Blues",
+	"Lightness": "Lightness",
+	"Chroma": "Colorfulness",
+	"Saturation": "Colorfulness",
+	"Hue": "Hue",
+	"a": "Opponent a",
+	"b": "Opponent b",
+};
+
+const PERCENTAGE = /^[-+]?(?:\d+\.?\d*|\.\d+)(?:e[-+]?\d+)?%$/i;
+
+/* ---------------------------------------------------------------- parsing -- */
+
+/** Split on a separator, ignoring separators nested inside parentheses */
+function splitTopLevel (str, separator = ",") {
+	let parts = [];
+	let depth = 0;
+	let current = "";
+
+	for (let char of str) {
+		if (char === "(") {
+			depth++;
+		}
+		else if (char === ")") {
+			depth--;
+		}
+
+		if (char === separator && depth === 0) {
+			parts.push(current);
+			current = "";
+		}
+		else {
+			current += char;
+		}
+	}
+
+	parts.push(current);
+	return parts;
+}
+
+/** Split on whitespace, keeping parenthesised functions in one piece */
+function tokenize (str) {
+	let tokens = [];
+	let depth = 0;
+	let current = "";
+
+	for (let char of str) {
+		if (char === "(") {
+			depth++;
+		}
+		else if (char === ")") {
+			depth--;
+		}
+
+		if (depth === 0 && /\s/.test(char)) {
+			if (current) {
+				tokens.push(current);
+				current = "";
+			}
+		}
+		else {
+			current += char;
+		}
+	}
+
+	if (current) {
+		tokens.push(current);
+	}
+
+	return tokens;
+}
+
+function balanced (str) {
+	let depth = 0;
+
+	for (let char of str) {
+		if (char === "(") {
+			depth++;
+		}
+		else if (char === ")") {
+			depth--;
+		}
+
+		if (depth < 0) {
+			return false;
+		}
+	}
+
+	return depth === 0;
+}
+
+/** Parse `in <color-space> <hue-interpolation-method>?` */
+function parseInterpolationMethod (str) {
+	let tokens = tokenize(str);
+	tokens.shift(); // the "in" keyword, already matched by the caller
+
+	let space = (tokens.shift() ?? "").toLowerCase();
+
+	if (!space) {
+		throw new SyntaxError("“in” must be followed by a color space.");
+	}
+
+	if (!(space in SPACES)) {
+		throw new SyntaxError(`“${ space }” is not a <color-space> that CSS allows for interpolation. Pick one of: ${ Object.keys(SPACES).join(", ") }.`);
+	}
+
+	let hueMethod = null;
+
+	if (tokens.length > 0) {
+		if (tokens.length !== 2 || tokens[1].toLowerCase() !== "hue") {
+			throw new SyntaxError(`Expected a <hue-interpolation-method> such as “longer hue”, got “${ tokens.join(" ") }”.`);
+		}
+
+		hueMethod = tokens[0].toLowerCase();
+
+		if (!HUE_METHODS.includes(hueMethod)) {
+			throw new SyntaxError(`“${ hueMethod } hue” is not a <hue-interpolation-method>. Use one of: ${ HUE_METHODS.join(", ") }.`);
+		}
+
+		if (!POLAR_SPACES.includes(space)) {
+			throw new SyntaxError(`A <hue-interpolation-method> is only allowed with a <polar-color-space>, and ${ space } is rectangular.`);
+		}
+	}
+
+	return { space, hueMethod };
+}
+
+/** Parse one `<color> && <percentage>?` argument */
+function parseMixItem (str, index) {
+	let tokens = tokenize(str);
+
+	if (tokens.length === 0) {
+		throw new SyntaxError("Empty argument: every argument must contain a <color>.");
+	}
+
+	let percentageTokens = tokens.filter(token => PERCENTAGE.test(token));
+
+	if (percentageTokens.length > 1) {
+		throw new SyntaxError(`Argument ${ index + 1 } has more than one <percentage>: “${ str.trim() }”.`);
+	}
+
+	let percentage = null;
+
+	if (percentageTokens.length === 1) {
+		let token = percentageTokens[0];
+		let position = tokens.indexOf(token);
+
+		if (position !== 0 && position !== tokens.length - 1) {
+			throw new SyntaxError(`The <percentage> in argument ${ index + 1 } must come before or after the <color>, not inside it.`);
+		}
+
+		percentage = Number(token.slice(0, -1));
+
+		if (percentage < 0) {
+			throw new SyntaxError(`Negative percentages are not allowed in color-mix(): “${ token }”.`);
+		}
+
+		if (percentage > 100) {
+			throw new SyntaxError(`Percentages in color-mix() are restricted to the range [0, 100]: “${ token }”.`);
+		}
+
+		tokens.splice(position, 1);
+	}
+
+	let colorString = tokens.join(" ");
+
+	if (!colorString) {
+		throw new SyntaxError(`Argument ${ index + 1 } is only a <percentage>; it also needs a <color>.`);
+	}
+
+	let color;
+	let nested = null;
+
+	if (/^color-mix\s*\(/i.test(colorString)) {
+		// color-mix() is itself a <color>, so it can be nested
+		nested = computeColorMix(colorString);
+		color = nested.color;
+	}
+	else {
+		try {
+			color = normalizeColor(new Color(colorString));
+		}
+		catch (error) {
+			throw new SyntaxError(`Cannot parse “${ colorString }” as a <color>.`);
+		}
+	}
+
+	return { colorString, color, percentage, nested };
+}
+
+/**
+ * Parse a color-mix() function.
+ * color-mix() = color-mix( <color-interpolation-method>? , [ <color> && <percentage [0,100]>? ]# )
+ */
+export function parseColorMix (input) {
+	let str = String(input).trim();
+	let match = str.match(/^color-mix\s*\(([\s\S]*)\)$/i);
+
+	if (!match || !balanced(match[1])) {
+		throw new SyntaxError("Expected a color-mix() function, for example color-mix(in oklch, peru 40%, palegoldenrod).");
+	}
+
+	let args = splitTopLevel(match[1]).map(arg => arg.trim());
+	let methodGiven = /^in(\s|$)/i.test(args[0]);
+	let { space, hueMethod } = methodGiven
+		? parseInterpolationMethod(args.shift())
+		: { space: DEFAULT_SPACE, hueMethod: null };
+
+	if (args.length === 0 || (args.length === 1 && args[0] === "")) {
+		throw new SyntaxError("color-mix() needs at least one <color> to mix.");
+	}
+
+	let items = args.map((arg, i) => parseMixItem(arg, i));
+
+	return {
+		space,
+		spaceId: SPACES[space],
+		hueMethod,
+		methodGiven,
+		hueArc: hueMethod ?? "shorter",
+		isPolar: POLAR_SPACES.includes(space),
+		items,
+	};
+}
+
+/* -------------------------------------------------- percentage normalization -- */
+
+/**
+ * Normalize mix percentages, CSS Values 5 6.1.
+ * color-mix() invokes this with the force normalization flag set.
+ * `percentages` holds one number, or null for an omitted percentage, per mix item.
+ */
+export function normalizeMixPercentages (percentages, force = false) {
+	let specified = percentages.filter(p => p !== null);
+	let specifiedSum = Math.min(specified.reduce((sum, p) => sum + p, 0), 100);
+	let omittedCount = percentages.length - specified.length;
+	let share = omittedCount > 0 ? (100 - specifiedSum) / omittedCount : null;
+	let filled = percentages.map(p => (p === null ? share : p));
+	let total = filled.reduce((sum, p) => sum + p, 0);
+	let scaled = total > 100 || (total > 0 && force);
+	let factor = scaled ? 100 / total : 1;
+	let normalized = filled.map(p => p * factor);
+	let leftover = total < 100 ? 100 - total : 0;
+
+	return { specifiedSum, omittedCount, share, filled, total, scaled, factor, normalized, leftover };
+}
+
+/* ------------------------------------------------------ missing components -- */
+
+/** Color.js uses null for missing components, but conversions can also yield NaN */
+function normalizeColor (color) {
+	return {
+		space: color.space,
+		spaceId: color.spaceId,
+		coords: [...color.coords].map(v => (v === null || Number.isNaN(v) ? null : v)),
+		alpha: color.alpha === null || Number.isNaN(color.alpha) ? null : color.alpha,
+	};
+}
+
+/** The analogous category of each component of a space, or null if it has none */
+function analogousCategories (space) {
+	return Object.values(space.coords).map(coord => ANALOGOUS[coord.name] ?? null);
+}
+
+export function componentNames (space) {
+	return Object.values(space.coords).map(coord => coord.name);
+}
+
+/**
+ * Convert a color to the interpolation space, carrying missing components
+ * forward as described in CSS Color 4 13.3.
+ */
+export function convertForInterpolation (color, space) {
+	let converted = normalizeColor(new Color(color.spaceId, color.coords, color.alpha).to(space.id));
+
+	// Color.js applies the "powerless component" rule of CSS Color 4 4.4.1 while
+	// converting, so an achromatic color arrives here with its hue already missing.
+	let powerless = converted.coords
+		.map((v, i) => (v === null && color.spaceId !== space.id ? i : -1))
+		.filter(i => i >= 0);
+
+	let coords = [...converted.coords];
+	let carried = [];
+
+	if (color.spaceId === space.id) {
+		// Nothing was converted, so every component is trivially analogous to itself
+		color.coords.forEach((v, i) => {
+			if (v === null) {
+				coords[i] = null;
+				carried.push(i);
+			}
+		});
+	}
+	else {
+		let from = analogousCategories(color.space);
+		let to = analogousCategories(space);
+		let shared = from.filter(category => category !== null && to.includes(category));
+
+		// Individually analogous components
+		from.forEach((category, i) => {
+			if (shared.includes(category) && color.coords[i] === null) {
+				let j = to.indexOf(category);
+				coords[j] = null;
+				carried.push(j);
+			}
+		});
+
+		// Whatever remains once the individually analogous components are removed
+		// forms an analogous set of its own
+		let fromRest = from.map((category, i) => i).filter(i => !shared.includes(from[i]));
+		let toRest = to.map((category, i) => i).filter(i => !shared.includes(to[i]));
+
+		if (fromRest.length > 0 && toRest.length > 0 && fromRest.every(i => color.coords[i] === null)) {
+			toRest.forEach(j => {
+				if (coords[j] !== null) {
+					carried.push(j);
+				}
+
+				coords[j] = null;
+			});
+		}
+	}
+
+	// Alpha is analogous to alpha
+	let alpha = color.alpha === null ? null : converted.alpha;
+
+	return {
+		converted,
+		result: { space, spaceId: space.id, coords, alpha },
+		carried,
+		powerless: powerless.filter(i => !carried.includes(i)),
+	};
+}
+
+/* -------------------------------------------------------------- interpolation -- */
+
+/** Hue fix-up, CSS Color 4 13.5 */
+export function adjustHues (arc, hue1, hue2) {
+	if (hue1 === null || hue2 === null) {
+		return [hue1, hue2];
+	}
+
+	// Constrain to [0deg, 360deg) without a modulo round trip,
+	// which would perturb the last bits of an angle that is already in range
+	let constrain = angle => (angle >= 0 && angle < 360 ? angle : ((angle % 360) + 360) % 360);
+	let θ1 = constrain(hue1);
+	let θ2 = constrain(hue2);
+	let difference = θ2 - θ1;
+
+	if (arc === "shorter") {
+		if (difference > 180) {
+			θ1 += 360;
+		}
+		else if (difference < -180) {
+			θ2 += 360;
+		}
+	}
+	else if (arc === "longer") {
+		if (-180 < difference && difference < 180) {
+			if (difference > 0) {
+				θ1 += 360;
+			}
+			else {
+				θ2 += 360;
+			}
+		}
+	}
+	else if (arc === "increasing") {
+		if (difference < 0) {
+			θ2 += 360;
+		}
+	}
+	else if (arc === "decreasing") {
+		if (difference > 0) {
+			θ1 += 360;
+		}
+	}
+
+	return [θ1, θ2];
+}
+
+function premultiply (color, hueIndex) {
+	// "If the alpha value is none, the premultiplied value is the un-premultiplied value"
+	if (color.alpha === null) {
+		return { ...color, coords: [...color.coords] };
+	}
+
+	return {
+		...color,
+		coords: color.coords.map((v, i) => (v === null || i === hueIndex ? v : v * color.alpha)),
+	};
+}
+
+function unpremultiply (color, hueIndex) {
+	// "If the interpolated alpha value is zero or none,
+	//  the un-premultiplied value is the premultiplied value"
+	if (color.alpha === null || color.alpha === 0) {
+		return { ...color, coords: [...color.coords] };
+	}
+
+	return {
+		...color,
+		coords: color.coords.map((v, i) => (v === null || i === hueIndex ? v : v / color.alpha)),
+	};
+}
+
+function lerp (start, end, p) {
+	if (start === null) {
+		return end;
+	}
+
+	if (end === null) {
+		return start;
+	}
+
+	return start + (end - start) * p;
+}
+
+/**
+ * Interpolate two colors that are already in the interpolation space,
+ * recording the value of every component at each stage.
+ */
+export function interpolatePair (colorA, colorB, p, space, hueArc) {
+	let hueIndex = space.hueIndex;
+	let a = { space, spaceId: space.id, coords: [...colorA.coords], alpha: colorA.alpha };
+	let b = { space, spaceId: space.id, coords: [...colorB.coords], alpha: colorB.alpha };
+
+	// A missing component takes the other color's value. This has to happen before
+	// premultiplication, so that a carried-forward missing alpha premultiplies with
+	// the value it inherits rather than with the zero it would otherwise become.
+	for (let i = 0; i < a.coords.length; i++) {
+		if (a.coords[i] === null && b.coords[i] !== null) {
+			a.coords[i] = b.coords[i];
+		}
+		else if (b.coords[i] === null && a.coords[i] !== null) {
+			b.coords[i] = a.coords[i];
+		}
+	}
+
+	if (a.alpha === null && b.alpha !== null) {
+		a.alpha = b.alpha;
+	}
+	else if (b.alpha === null && a.alpha !== null) {
+		b.alpha = a.alpha;
+	}
+
+	let filled = [{ ...a, coords: [...a.coords] }, { ...b, coords: [...b.coords] }];
+	let hues = null;
+
+	if (hueIndex >= 0) {
+		let before = [a.coords[hueIndex], b.coords[hueIndex]];
+		let after = adjustHues(hueArc, before[0], before[1]);
+		a.coords[hueIndex] = after[0];
+		b.coords[hueIndex] = after[1];
+		hues = { arc: hueArc, before, after };
+	}
+
+	let adjusted = [{ ...a, coords: [...a.coords] }, { ...b, coords: [...b.coords] }];
+	let premultiplied = [premultiply(a, hueIndex), premultiply(b, hueIndex)];
+	let mixed = {
+		space,
+		spaceId: space.id,
+		coords: premultiplied[0].coords.map((start, i) => lerp(start, premultiplied[1].coords[i], p)),
+		alpha: lerp(a.alpha, b.alpha, p),
+	};
+	let result = unpremultiply(mixed, hueIndex);
+
+	return { hueIndex, filled, hues, adjusted, premultiplied, mixed, result };
+}
+
+/* ------------------------------------------------------------------ the mix -- */
+
+/**
+ * Compute a color-mix(), returning both the resulting color
+ * and a trace of every stage of the algorithm.
+ */
+export function computeColorMix (input) {
+	let parsed = parseColorMix(input);
+	let space = Color.spaces[parsed.spaceId];
+
+	// 1. Normalize mix percentages, with the forced normalization flag set to true
+	let normalization = normalizeMixPercentages(parsed.items.map(item => item.percentage), true);
+
+	// 2. Let alpha mult be 1 - leftover
+	let alphaMult = 1 - normalization.leftover / 100;
+
+	// 3. Convert every color to the specified interpolation color space
+	let conversions = parsed.items.map(item => convertForInterpolation(item.color, space));
+
+	let items = parsed.items.map((item, i) => ({
+		...item,
+		normalized: normalization.normalized[i],
+		conversion: conversions[i],
+		interpolated: conversions[i].result,
+	}));
+
+	// 4. Mix the items pairwise off a stack, in the order they were written
+	let stack = items
+		.map((item, i) => ({ label: `color ${ i + 1 }`, color: item.interpolated, percentage: item.normalized }))
+		.reverse();
+	let iterations = [];
+
+	while (stack.length >= 2) {
+		let a = stack.pop();
+		let b = stack.pop();
+		let combined = a.percentage + b.percentage;
+		let p = combined > 0 ? b.percentage / combined : 0.5;
+		let trace = interpolatePair(a.color, b.color, p, space, parsed.hueArc);
+		let pushed = {
+			label: `mix of ${ a.label } and ${ b.label }`,
+			color: trace.result,
+			percentage: combined,
+		};
+
+		iterations.push({ a, b, combined, p, trace, pushed });
+		stack.push(pushed);
+	}
+
+	let mixedColor = stack[0].color;
+
+	// 5. Multiply the alpha component of color by alpha mult
+	let color = {
+		space,
+		spaceId: space.id,
+		coords: [...mixedColor.coords],
+		// A missing alpha stays missing: there is no value there to scale
+		alpha: mixedColor.alpha === null ? null : mixedColor.alpha * alphaMult,
+	};
+
+	// 6. Return color
+	return { input, parsed, space, normalization, alphaMult, items, iterations, color };
+}
+
+/** Turn one of the plain color records used above back into a Color.js object */
+export function toColor (color) {
+	return new Color(color.spaceId ?? color.space.id, color.coords, color.alpha);
+}

--- a/color-mix/colormix.js
+++ b/color-mix/colormix.js
@@ -290,7 +290,9 @@ export function parseColorMix (input) {
  * Normalize mix percentages.
  * CSS Values 5 § 6.1 Normalizing Mix Percentages
  * <https://drafts.csswg.org/css-values-5/#mix-percentage-normalization>
- * (linked to the Editor's Draft: the section is not in the TR version yet)
+ * Linked to the Editor's Draft because the TR version is stale and does not
+ * have this section yet; switch to /TR once it is republished.
+ * <https://github.com/w3c/csswg-drafts/issues/14435>
  *
  * color-mix() invokes this with the force normalization flag set.
  * `percentages` holds one number, or null for an omitted percentage, per mix item.

--- a/color-mix/colormix.js
+++ b/color-mix/colormix.js
@@ -1,6 +1,7 @@
 /**
  * A traced implementation of CSS Color 5 color-mix(),
- * following https://www.w3.org/TR/css-color-5/#color-mix-result
+ * following § 3.3 Calculating the Result of color-mix
+ * <https://www.w3.org/TR/css-color-5/#color-mix-result>
  * step by step so that every intermediate value can be displayed.
  *
  * Color.js is used for parsing colors and for color space conversion,
@@ -35,11 +36,18 @@ export const POLAR_SPACES = ["hsl", "hwb", "lch", "oklch"];
 /** <hue-interpolation-method> */
 export const HUE_METHODS = ["shorter", "longer", "increasing", "decreasing"];
 
-/** If no <color-interpolation-method> is given, CSS Color 5 3.1 says to assume Oklab */
+/**
+ * If no <color-interpolation-method> is given, assume Oklab.
+ * CSS Color 5 § 3.1 Colorspace for mixing
+ * <https://www.w3.org/TR/css-color-5/#color-mix-space>
+ */
 export const DEFAULT_SPACE = "oklab";
 
 /**
- * Analogous components, CSS Color 4 13.3.
+ * Analogous components.
+ * CSS Color 4 § 13.3 Interpolating with Missing Components
+ * <https://www.w3.org/TR/css-color-4/#interpolation-missing>
+ *
  * Keyed by the component names Color.js uses, which are distinct across spaces
  * (HWB's "Blackness" is deliberately not the same as sRGB's "Blue").
  * Whiteness and Blackness have no analogs, so they are absent here.
@@ -279,7 +287,11 @@ export function parseColorMix (input) {
 /* -------------------------------------------------- percentage normalization -- */
 
 /**
- * Normalize mix percentages, CSS Values 5 6.1.
+ * Normalize mix percentages.
+ * CSS Values 5 § 6.1 Normalizing Mix Percentages
+ * <https://drafts.csswg.org/css-values-5/#mix-percentage-normalization>
+ * (linked to the Editor's Draft: the section is not in the TR version yet)
+ *
  * color-mix() invokes this with the force normalization flag set.
  * `percentages` holds one number, or null for an omitted percentage, per mix item.
  */
@@ -320,14 +332,17 @@ export function componentNames (space) {
 }
 
 /**
- * Convert a color to the interpolation space, carrying missing components
- * forward as described in CSS Color 4 13.3.
+ * Convert a color to the interpolation space, carrying missing components forward.
+ * CSS Color 4 § 13.3 Interpolating with Missing Components
+ * <https://www.w3.org/TR/css-color-4/#interpolation-missing>
  */
 export function convertForInterpolation (color, space) {
 	let converted = normalizeColor(new Color(color.spaceId, color.coords, color.alpha).to(space.id));
 
-	// Color.js applies the "powerless component" rule of CSS Color 4 4.4.1 while
-	// converting, so an achromatic color arrives here with its hue already missing.
+	// Color.js applies the "powerless component" rule while converting, so an achromatic
+	// color arrives here with its hue already missing.
+	// CSS Color 4 § 4.4.1 "Powerless" Color Components
+	// <https://www.w3.org/TR/css-color-4/#powerless>
 	let powerless = converted.coords
 		.map((v, i) => (v === null && color.spaceId !== space.id ? i : -1))
 		.filter(i => i >= 0);
@@ -387,7 +402,11 @@ export function convertForInterpolation (color, space) {
 
 /* -------------------------------------------------------------- interpolation -- */
 
-/** Hue fix-up, CSS Color 4 13.5 */
+/**
+ * Hue fix-up.
+ * CSS Color 4 § 13.5 Hue Interpolation
+ * <https://www.w3.org/TR/css-color-4/#hue-interpolation>
+ */
 export function adjustHues (arc, hue1, hue2) {
 	if (hue1 === null || hue2 === null) {
 		return [hue1, hue2];
@@ -431,6 +450,12 @@ export function adjustHues (arc, hue1, hue2) {
 
 	return [θ1, θ2];
 }
+
+/*
+ * The quoted rules in premultiply() and unpremultiply() below are from
+ * CSS Color 4 § 13.4 Interpolating with Alpha
+ * <https://www.w3.org/TR/css-color-4/#interpolation-alpha>
+ */
 
 function premultiply (color, hueIndex) {
 	// "If the alpha value is none, the premultiplied value is the un-premultiplied value"

--- a/color-mix/index.html
+++ b/color-mix/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>color-mix() step by step</title>
+<link rel="shortcut icon" href="https://colorjs.io/logo.svg">
+<link rel="stylesheet" href="style.css">
+
+<!-- Must come before any module script, including the one the Eleventy dev server
+     injects into <head>: an import map is rejected once a module load has started. -->
+<script src="../importmap.js"></script>
+
+</head>
+<body>
+
+<h1><code>color-mix()</code> step by step</h1>
+
+<p class="intro">
+	Type any legal <a href="https://www.w3.org/TR/css-color-5/#color-mix">CSS Color 5 <code>color-mix()</code></a> value.
+	It is parsed here in JavaScript, every color is listed both in its own color space and in the mixing color space,
+	and each stage of <a href="https://www.w3.org/TR/css-color-5/#color-mix-result">the color-mix() algorithm</a>
+	is shown with the value of every component.
+</p>
+
+<form class="inputs" id="form">
+	<label for="input"><code>color-mix()</code> value</label>
+	<input type="text" id="input" spellcheck="false" autocapitalize="off" autocomplete="off"
+	       value="color-mix(in lch, peru 40%, palegoldenrod)">
+	<a id="permalink" href="">Permalink</a>
+</form>
+
+<div class="examples">
+	<span>Try:</span>
+	<button type="button">color-mix(in lch, teal 65%, olive)</button>
+	<button type="button">color-mix(in oklch, white, blue)</button>
+	<button type="button">color-mix(in srgb, red 20%, blue 20%)</button>
+	<button type="button">color-mix(in srgb, rgb(100% 0% 0% / 0.7) 20%, rgb(0% 100% 0% / 0.2) 60%)</button>
+	<button type="button">color-mix(in oklch longer hue, oklch(70% 0.2 20), oklch(70% 0.2 300))</button>
+	<button type="button">color-mix(in oklch, lch(50% 0.02 none), color(display-p3 0.7 0.5 none))</button>
+	<button type="button">color-mix(in hsl, color(display-p3 0 1 0) 80%, yellow)</button>
+	<button type="button">color-mix(in xyz, white, black)</button>
+	<button type="button">color-mix(in oklch, red, green, blue)</button>
+	<button type="button">color-mix(firebrick, goldenrod)</button>
+</div>
+
+<p class="error" id="error" hidden></p>
+
+<div id="output" hidden></div>
+
+<div id="probe" aria-hidden="true"></div>
+
+<footer>
+	A <a href="https://colorjs.io">Color.js</a> app.
+	The mixing is implemented from the specification rather than delegated to Color.js,
+	so that every intermediate value can be shown; Color.js does the color parsing and the
+	color space conversions. <a href="https://github.com/color-js/apps/tree/main/color-mix">Source</a>.
+</footer>
+
+<script type="module" src="index.js"></script>
+</body>
+</html>

--- a/color-mix/index.js
+++ b/color-mix/index.js
@@ -1,0 +1,521 @@
+import Color from "colorjs.io";
+import { computeColorMix, componentNames, toColor, DEFAULT_SPACE } from "./colormix.js";
+
+const PRECISION = 5;
+
+/* ------------------------------------------------------------- formatting -- */
+
+function esc (str) {
+	return String(str).replace(/[&<>"]/g, char => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;" })[char]);
+}
+
+/** Format one component value; a missing component is the CSS keyword none */
+function fmt (value) {
+	if (value === null || value === undefined) {
+		return "none";
+	}
+
+	if (!Number.isFinite(value)) {
+		return String(value);
+	}
+
+	return String(Number(value.toPrecision(6)));
+}
+
+/**
+ * Write a color out longhand, without the clipping or renormalization that
+ * Color.js applies when it serializes a color outside its own reference range.
+ */
+function longhand (c) {
+	let coords = c.coords;
+	let alpha = c.alpha === 1 ? "" : ` / ${ fmt(c.alpha) }`;
+
+	if (c.spaceId === "hsl" || c.spaceId === "hwb") {
+		return `${ c.spaceId }(${ fmt(coords[0]) } ${ fmt(coords[1]) }% ${ fmt(coords[2]) }%${ alpha })`;
+	}
+
+	return `color(${ c.space.cssId ?? c.spaceId } ${ coords.map(fmt).join(" ") }${ alpha })`;
+}
+
+function serialize (color, precision = PRECISION) {
+	let c;
+
+	try {
+		c = toColor(color);
+	}
+	catch (error) {
+		return "(cannot be serialized)";
+	}
+
+	// Only the sRGB-based spaces have a reference range that Color.js enforces when
+	// serializing; a mix in one of those can land outside it, and clipping would show
+	// a different color from the one in the component tables.
+	try {
+		if (!c.inGamut(c.spaceId)) {
+			return longhand(c);
+		}
+	}
+	catch (error) {
+		// A space with no gamut of its own; nothing to clip
+	}
+
+	return c.toString({ precision });
+}
+
+/**
+ * A CSS color the browser can actually paint, in the color's own color space
+ * wherever possible, so that the browser does the gamut mapping for the display.
+ * Missing components render as zero, which is what CSS does with none.
+ */
+function cssColor (color) {
+	let c;
+
+	try {
+		c = toColor({
+			spaceId: color.spaceId,
+			coords: color.coords.map(v => v ?? 0),
+			alpha: color.alpha ?? 0,
+		});
+	}
+	catch (error) {
+		return "transparent";
+	}
+
+	// Color.js clips or renormalizes when it serializes an sRGB-based space, which would
+	// paint a different color from the one described alongside it. OkLCh survives
+	// serialization intact, so hand the browser that and let it map to the display gamut.
+	try {
+		if (!c.inGamut(c.spaceId)) {
+			c = c.to("oklch");
+		}
+	}
+	catch (error) {
+		// A space with no gamut of its own; nothing is clipped
+	}
+
+	try {
+		return String(c.display());
+	}
+	catch (error) {
+		return c.to("srgb").toString();
+	}
+}
+
+function swatch (color, extraClass = "") {
+	return `<span class="swatch ${ extraClass }" style="--color: ${ esc(cssColor(color)) }"></span>`;
+}
+
+/* ----------------------------------------------------------- component tables -- */
+
+/**
+ * A table of component values: one column per component of `space` plus alpha,
+ * one row per stage.
+ * rows: [{label, color, note, muted, swatch}]
+ */
+function componentsTable (space, rows, caption) {
+	let names = componentNames(space);
+	let head = names.map(name => `<th scope="col">${ esc(name) }</th>`).join("");
+
+	let body = rows.map(row => {
+		let cells = row.color.coords.map(v => {
+			return `<td class="${ v === null ? "missing" : "" }">${ fmt(v) }</td>`;
+		}).join("");
+		let alpha = `<td class="${ row.color.alpha === null ? "missing" : "" }">${ fmt(row.color.alpha) }</td>`;
+		let label = (row.swatch ? swatch(row.color) : "") + esc(row.label)
+			+ (row.note ? ` <span class="note">(${ esc(row.note) })</span>` : "");
+
+		return `<tr class="${ row.muted ? "muted" : "" }"><th scope="row">${ label }</th>${ cells }${ alpha }</tr>`;
+	}).join("");
+
+	return `<div class="scroller"><table class="components">
+		${ caption ? `<caption>${ caption }</caption>` : "" }
+		<thead><tr><th scope="col"></th>${ head }<th scope="col">alpha</th></tr></thead>
+		<tbody>${ body }</tbody>
+	</table></div>`;
+}
+
+function sameColor (a, b) {
+	return a.alpha === b.alpha && a.coords.every((v, i) => v === b.coords[i]);
+}
+
+/* ------------------------------------------------------------------ sections -- */
+
+function renderResult (mix, input) {
+	let result = toColor(mix.color);
+	let inSRGB = result.inGamut("srgb");
+	let srgb = result.to("srgb");
+	let srgbString = serialize({ spaceId: "srgb", coords: srgb.coords, alpha: srgb.alpha });
+	let inP3 = result.inGamut("p3");
+	let p3 = result.to("p3");
+	let p3String = serialize({ spaceId: "p3", coords: p3.coords, alpha: p3.alpha });
+
+	let browser = compareWithBrowser(mix, input);
+
+	return `<section class="result">
+		<h2>Result</h2>
+		<div class="result-grid">
+			<div class="swatch huge" style="--color: ${ esc(cssColor(mix.color)) }"></div>
+			<dl>
+				<dt>In the mixing color space (${ esc(mix.space.name) })</dt>
+				<dd><code>${ esc(serialize(mix.color)) }</code></dd>
+				<dt>In sRGB</dt>
+				<dd>
+					<code>${ esc(srgbString) }</code>
+					${ inSRGB ? "" : ` <span class="note">outside the sRGB gamut</span>` }
+				</dd>
+				<dt>In Display P3</dt>
+				<dd>
+					<code>${ esc(p3String) }</code>
+					${ inP3 ? "" : ` <span class="note">outside the Display P3 gamut</span>` }
+				</dd>
+			</dl>
+		</div>
+		${ browser }
+	</section>`;
+}
+
+/** Ask the browser to compute the same color-mix(), as a cross-check */
+function compareWithBrowser (mix, input) {
+	let probe = document.getElementById("probe");
+	probe.style.color = "";
+	probe.style.color = input;
+
+	if (probe.style.color === "") {
+		return `<p class="browser">Your browser does not accept this value, so there is nothing to compare against.
+			CSS Color 5 allows any number of colors in <code>color-mix()</code>, but implementations currently only take two.</p>`;
+	}
+
+	let computed = getComputedStyle(probe).color;
+	let theirs;
+
+	try {
+		theirs = new Color(computed);
+	}
+	catch (error) {
+		return `<p class="browser">Your browser computed <code>${ esc(computed) }</code>, which could not be parsed for comparison.</p>`;
+	}
+
+	let ours = toColor(mix.color);
+	let ΔE = ours.deltaE(theirs, "2000");
+	// Well below a just-noticeable difference: this only has to absorb the rounding in
+	// the browser's serialization, which grows for colors far outside the sRGB gamut.
+	let close = ΔE < 0.1;
+
+	return `<p class="browser ${ close ? "agrees" : "differs" }">
+		${ swatch({ spaceId: theirs.spaceId, coords: theirs.coords, alpha: theirs.alpha }) }
+		Your browser computes this as <code>${ esc(computed) }</code>,
+		which is ΔE<sub>00</sub> ${ fmt(ΔE) } away from the result above${ close ? " — they agree" : "" }.
+	</p>`;
+}
+
+function renderParse (mix) {
+	let { parsed } = mix;
+	let hue = parsed.isPolar
+		? `<dt>Hue interpolation method</dt><dd><code>${ esc(parsed.hueArc) } hue</code>${ parsed.hueMethod ? "" : ` <span class="note">not specified, so <code>shorter</code> is assumed</span>` }</dd>`
+		: `<dt>Hue interpolation method</dt><dd>not applicable: ${ esc(parsed.space) } is a <code>&lt;rectangular-color-space&gt;</code></dd>`;
+
+	return `<section>
+		<h2>1. The parsed function</h2>
+		<p class="grammar"><code>color-mix() = color-mix( &lt;color-interpolation-method&gt;? , [ &lt;color&gt; &amp;&amp; &lt;percentage [0,100]&gt;? ]# )</code></p>
+		<dl class="parse">
+			<dt>Mixing color space</dt>
+			<dd>
+				<code>${ esc(parsed.space) }</code> (${ esc(mix.space.name) }), a
+				<code>&lt;${ parsed.isPolar ? "polar" : "rectangular" }-color-space&gt;</code>
+				${ parsed.methodGiven ? "" : `<span class="note">no <code>&lt;color-interpolation-method&gt;</code> was given, so ${ DEFAULT_SPACE } is assumed</span>` }
+			</dd>
+			${ hue }
+			<dt>Colors to mix</dt>
+			<dd>${ parsed.items.length }</dd>
+		</dl>
+	</section>`;
+}
+
+function renderColors (mix) {
+	let cards = mix.items.map((item, i) => {
+		let origin = item.color;
+		let conversion = item.conversion;
+		let notes = [];
+
+		if (item.nested) {
+			notes.push("This argument is itself a <code>color-mix()</code>, resolved first.");
+		}
+
+		if (conversion.carried.length > 0) {
+			let carried = [...new Set(conversion.carried)].map(j => componentNames(mix.space)[j]);
+			notes.push(`Missing component${ carried.length > 1 ? "s" : "" } carried forward into ${ esc(mix.space.name) } as analogous: <b>${ carried.map(esc).join(", ") }</b>.`);
+		}
+
+		if (conversion.powerless.length > 0) {
+			let powerless = conversion.powerless.map(j => componentNames(mix.space)[j]);
+			notes.push(`Became missing during conversion because ${ powerless.length > 1 ? "they are" : "it is" } <a href="https://www.w3.org/TR/css-color-4/#powerless">powerless</a> for this color: <b>${ powerless.map(esc).join(", ") }</b>.`);
+		}
+
+		let sameSpace = origin.spaceId === mix.space.id;
+		let carriedAnything = conversion.carried.length > 0;
+		let interpolationRows = carriedAnything
+			? [
+				{ label: `in ${ mix.space.name }`, color: conversion.converted, note: "straight conversion", muted: true },
+				{ label: `in ${ mix.space.name }`, color: conversion.result, note: "missing components carried forward" },
+			]
+			: [{ label: `in ${ mix.space.name }`, color: conversion.result }];
+
+		return `<div class="color-card">
+			<div class="color-card-head">
+				<span class="swatch big" style="--color: ${ esc(cssColor(origin)) }"></span>
+				<div>
+					<code class="written">${ esc(item.colorString) }</code>
+					<p class="pct">
+						Specified percentage: <b>${ item.percentage === null ? "omitted" : fmt(item.percentage) + "%" }</b>
+						&middot; after normalization: <b>${ fmt(mix.normalization.normalized[i]) }%</b>
+					</p>
+				</div>
+			</div>
+			${ componentsTable(origin.space, [
+				{ label: `in ${ origin.space.name }`, color: origin },
+			], `Origin color space, ${ esc(origin.space.name) }: <code>${ esc(serialize(origin)) }</code>`) }
+			${ sameSpace
+				? `<p class="note same-space">Already in the mixing color space, so there is nothing to convert.</p>`
+				: componentsTable(mix.space, interpolationRows,
+					`Mixing color space, ${ esc(mix.space.name) }: <code>${ esc(serialize(conversion.result)) }</code>`) }
+			${ notes.length ? `<ul class="notes">${ notes.map(n => `<li>${ n }</li>`).join("") }</ul>` : "" }
+		</div>`;
+	}).join("");
+
+	return `<section>
+		<h2>2. The colors, in their own color space and in ${ esc(mix.space.name) }</h2>
+		<p>
+			Each color is converted to the mixing color space. Missing components (<code>none</code>) are
+			<a href="https://www.w3.org/TR/css-color-4/#interpolation-missing">carried forward</a> into any
+			analogous component rather than being converted to zero.
+		</p>
+		<div class="color-cards">${ cards }</div>
+	</section>`;
+}
+
+function renderNormalization (mix) {
+	let { normalization: n, parsed } = mix;
+	let steps = [];
+
+	steps.push(`<li>The <b>specified sum</b> is ${ fmt(n.specifiedSum) }%${ n.specifiedSum === 100 && parsed.items.some(i => i.percentage !== null) ? " (clamped to 100%)" : "" }.</li>`);
+
+	if (n.omittedCount > 0) {
+		steps.push(`<li>${ n.omittedCount } percentage${ n.omittedCount > 1 ? "s were" : " was" } omitted, so each is set to
+			(100% &minus; ${ fmt(n.specifiedSum) }%) / ${ n.omittedCount } = <b>${ fmt(n.share) }%</b>.</li>`);
+	}
+	else {
+		steps.push(`<li>No percentage was omitted, so there is nothing to distribute.</li>`);
+	}
+
+	steps.push(`<li>The <b>total</b> is now ${ fmt(n.total) }%.</li>`);
+
+	if (n.scaled && n.factor !== 1) {
+		steps.push(`<li>color-mix() sets the <b>force normalization</b> flag, so every percentage is multiplied by
+			100% / ${ fmt(n.total) }% = <b>${ fmt(n.factor) }</b>, bringing the sum to 100%.</li>`);
+	}
+	else if (n.scaled) {
+		steps.push(`<li>The percentages already sum to 100%, so scaling by 100% / ${ fmt(n.total) }% leaves them alone.</li>`);
+	}
+	else {
+		steps.push(`<li>The total is 0%, which is neither greater than 100% nor greater than 0%, so no scaling happens.</li>`);
+	}
+
+	steps.push(n.leftover > 0
+		? `<li>The total was less than 100%, so the <b>leftover</b> is 100% &minus; ${ fmt(n.total) }% = <b>${ fmt(n.leftover) }%</b>.</li>`
+		: `<li>The total was not less than 100%, so the <b>leftover</b> is <b>0%</b>.</li>`);
+
+	let rows = mix.items.map((item, i) => `<tr>
+		<th scope="row">${ swatch(item.color) }<code>${ esc(item.colorString) }</code></th>
+		<td>${ item.percentage === null ? "<i>omitted</i>" : fmt(item.percentage) + "%" }</td>
+		<td>${ fmt(n.filled[i]) }%</td>
+		<td>${ fmt(n.normalized[i]) }%</td>
+	</tr>`).join("");
+
+	return `<section>
+		<h2>3. Normalize the mix percentages</h2>
+		<p>
+			<a href="https://drafts.csswg.org/css-values-5/#mix-percentage-normalization">Normalizing mix percentages</a>
+			fills in any omitted percentage, scales the percentages so they sum to 100%,
+			and reports whatever percentage is left over.
+		</p>
+		<ol class="steps">${ steps.join("") }</ol>
+		<div class="scroller"><table class="components">
+			<thead><tr><th scope="col">Color</th><th scope="col">Specified</th><th scope="col">After filling omitted</th><th scope="col">Normalized</th></tr></thead>
+			<tbody>${ rows }</tbody>
+		</table></div>
+		<p class="callout"><b>alpha mult</b> = 1 &minus; leftover = 1 &minus; ${ fmt(n.leftover / 100) } = <b>${ fmt(mix.alphaMult) }</b>${ mix.alphaMult === 1 ? "" : `, so the mixed color ends up ${ fmt(mix.alphaMult * 100) }% as opaque as the colors it was mixed from` }</p>
+	</section>`;
+}
+
+function renderIterations (mix) {
+	if (mix.iterations.length === 0) {
+		return `<section>
+			<h2>4. Mix the colors</h2>
+			<p>Only one color was given, so the result is simply that color converted to ${ esc(mix.space.name) }. There is nothing to interpolate.</p>
+		</section>`;
+	}
+
+	let intro = `<p>
+		The mix items are pushed onto a stack in the order they were written. Two are popped at a time,
+		interpolated, and the result pushed back with their combined percentage. In a polar color space this
+		makes mixing order-dependent, since which way round the hue circle is “shorter” can change as the mix proceeds.
+	</p>`;
+
+	let blocks = mix.iterations.map((iteration, index) => {
+		let { a, b, combined, p, trace } = iteration;
+		let rows = [];
+		let notes = [];
+
+		rows.push({ label: `a — ${ a.label } (${ fmt(a.percentage) }%)`, color: a.color, swatch: true });
+		rows.push({ label: `b — ${ b.label } (${ fmt(b.percentage) }%)`, color: b.color, swatch: true });
+
+		// Each stage only gets its own rows if it actually changed something
+		if (!sameColor(trace.filled[0], a.color) || !sameColor(trace.filled[1], b.color)) {
+			rows.push({
+				label: "a, missing components filled in",
+				color: trace.filled[0],
+				muted: true,
+				note: sameColor(trace.filled[0], a.color) ? "unchanged" : "takes b’s value",
+			});
+			rows.push({
+				label: "b, missing components filled in",
+				color: trace.filled[1],
+				muted: true,
+				note: sameColor(trace.filled[1], b.color) ? "unchanged" : "takes a’s value",
+			});
+		}
+		else {
+			notes.push("Neither color has a missing component that the other supplies.");
+		}
+
+		if (trace.hues) {
+			let { arc, before, after } = trace.hues;
+
+			if (before.some((v, i) => v !== after[i])) {
+				rows.push({ label: `a, hue fixed up for ${ arc } hue`, color: trace.adjusted[0], muted: true });
+				rows.push({ label: `b, hue fixed up for ${ arc } hue`, color: trace.adjusted[1], muted: true });
+				notes.push(`The <code>${ esc(arc) } hue</code> fix-up turns ${ fmt(before[0]) } and ${ fmt(before[1]) }
+					into ${ fmt(after[0]) } and ${ fmt(after[1]) }, so that interpolating between them takes the intended arc.`);
+			}
+			else {
+				notes.push(`The <code>${ esc(arc) } hue</code> fix-up leaves both hues unchanged.`);
+			}
+		}
+
+		if (trace.premultiplied.some((c, i) => !sameColor(c, trace.adjusted[i]))) {
+			rows.push({ label: "a, premultiplied by its alpha", color: trace.premultiplied[0], muted: true });
+			rows.push({ label: "b, premultiplied by its alpha", color: trace.premultiplied[1], muted: true });
+		}
+		else {
+			notes.push("Both colors are fully opaque, so premultiplying changes nothing.");
+		}
+
+		rows.push({ label: `interpolated at p = ${ fmt(p) }`, color: trace.mixed, muted: true, note: "still premultiplied" });
+		rows.push({ label: "un-premultiplied", color: trace.result, swatch: true });
+
+		return `<div class="iteration">
+			<h3>Iteration ${ index + 1 }: mix ${ esc(a.label) } with ${ esc(b.label) }</h3>
+			<p class="calc">
+				combined percentage = ${ fmt(a.percentage) }% + ${ fmt(b.percentage) }% = <b>${ fmt(combined) }%</b><br>
+				progress p = ${ combined > 0
+					? `b’s percentage / combined percentage = ${ fmt(b.percentage) } / ${ fmt(combined) } = <b>${ fmt(p) }</b>`
+					: `<b>0.5</b>, because the combined percentage is 0%` }
+			</p>
+			${ notes.length ? `<ul class="notes">${ notes.map(n => `<li>${ n }</li>`).join("") }</ul>` : "" }
+			${ componentsTable(mix.space, rows) }
+			<p class="pushed">
+				Pushed back onto the stack:
+				${ swatch(trace.result) }<code>${ esc(serialize(trace.result)) }</code> at ${ fmt(combined) }%.
+			</p>
+		</div>`;
+	}).join("");
+
+	return `<section>
+		<h2>4. Mix the colors, two at a time</h2>
+		${ intro }
+		${ blocks }
+	</section>`;
+}
+
+function renderFinal (mix) {
+	let last = mix.iterations.length
+		? mix.iterations[mix.iterations.length - 1].trace.result
+		: mix.items[0].interpolated;
+
+	let note;
+
+	if (last.alpha === null) {
+		note = `<p class="note">The alpha of the mixed color is missing, so there is no value to scale; it stays <code>none</code>.</p>`;
+	}
+	else if (mix.alphaMult === 1) {
+		note = `<p class="note">alpha mult is 1, so the alpha is unchanged.</p>`;
+	}
+	else {
+		note = `<p class="calc">alpha = ${ fmt(last.alpha) } &times; ${ fmt(mix.alphaMult) } = <b>${ fmt(mix.color.alpha) }</b></p>`;
+	}
+
+	return `<section>
+		<h2>5. Multiply the alpha by alpha mult, and return</h2>
+		${ note }
+		${ componentsTable(mix.space, [
+			{ label: "before", color: last, muted: true },
+			{ label: "returned color", color: mix.color, swatch: true },
+		]) }
+	</section>`;
+}
+
+/* --------------------------------------------------------------------- app -- */
+
+let input = document.getElementById("input");
+let output = document.getElementById("output");
+let error = document.getElementById("error");
+let permalink = document.getElementById("permalink");
+
+function update () {
+	let value = input.value.trim();
+	let query = `?mix=${ encodeURIComponent(value) }`;
+	permalink.href = query;
+	history.replaceState(null, "", query);
+
+	let mix;
+
+	try {
+		mix = computeColorMix(value);
+	}
+	catch (e) {
+		error.textContent = e.message;
+		error.hidden = false;
+		output.hidden = true;
+		input.setCustomValidity(e.message);
+		return;
+	}
+
+	error.hidden = true;
+	input.setCustomValidity("");
+
+	output.innerHTML = renderResult(mix, value)
+		+ renderParse(mix)
+		+ renderColors(mix)
+		+ renderNormalization(mix)
+		+ renderIterations(mix)
+		+ renderFinal(mix);
+	output.hidden = false;
+}
+
+document.getElementById("form").addEventListener("submit", event => event.preventDefault());
+input.addEventListener("input", update);
+
+document.querySelector(".examples").addEventListener("click", event => {
+	if (event.target.matches("button")) {
+		input.value = event.target.textContent.trim();
+		update();
+	}
+});
+
+let params = new URL(location).searchParams;
+
+if (params.get("mix")) {
+	input.value = params.get("mix");
+}
+
+update();

--- a/color-mix/style.css
+++ b/color-mix/style.css
@@ -1,0 +1,407 @@
+:root {
+	--font-ui: system-ui, Helvetica Neue, Helvetica, Segoe UI, sans-serif;
+	--font-code: ui-monospace, SFMono-Regular, Consolas, Liberation Mono, monospace;
+	--hairline: hsl(220 15% 85%);
+	--muted: hsl(220 10% 40%);
+	--accent: oklch(55% 0.17 265);
+	--panel: hsl(220 25% 98%);
+}
+
+body {
+	font: 105%/1.5 var(--font-ui);
+	width: 92vw;
+	max-width: 76em;
+	margin: 1em auto 4em;
+	padding: 0 1em;
+	color: hsl(220 15% 15%);
+}
+
+h1 {
+	text-align: center;
+	font-weight: 600;
+}
+
+h1 code {
+	font-size: inherit;
+}
+
+.intro {
+	max-width: 46em;
+	margin: 0 auto 2em;
+	text-align: center;
+	color: var(--muted);
+}
+
+code {
+	font-family: var(--font-code);
+	font-size: 90%;
+}
+
+a {
+	color: var(--accent);
+}
+
+/* ------------------------------------------------------------------ inputs -- */
+
+.inputs {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: .8em;
+	margin-bottom: .8em;
+}
+
+.inputs label {
+	font-weight: 600;
+}
+
+.inputs input {
+	flex: 1;
+	min-width: 20em;
+	font-family: var(--font-code);
+	font-size: 105%;
+	padding: .5em .7em;
+	border: 2px solid var(--hairline);
+	border-radius: .3em;
+	background: white;
+}
+
+.inputs input:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 1px;
+	border-color: transparent;
+}
+
+.inputs input:invalid {
+	border-color: oklch(58% 0.21 25);
+}
+
+.examples {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: .4em;
+	margin-bottom: 1.5em;
+	font-size: 85%;
+	color: var(--muted);
+}
+
+.examples button {
+	font-family: var(--font-code);
+	font-size: 95%;
+	padding: .25em .6em;
+	border: 1px solid var(--hairline);
+	border-radius: 1em;
+	background: var(--panel);
+	color: inherit;
+	cursor: pointer;
+}
+
+.examples button:hover {
+	border-color: var(--accent);
+	color: var(--accent);
+}
+
+.error {
+	padding: .8em 1em;
+	border-radius: .3em;
+	border-inline-start: .4em solid oklch(58% 0.21 25);
+	background: oklch(96% 0.03 25);
+	color: oklch(35% 0.12 25);
+}
+
+/* ---------------------------------------------------------------- swatches -- */
+
+.swatch {
+	display: inline-block;
+	inline-size: 1.3em;
+	block-size: 1.3em;
+	vertical-align: -.3em;
+	margin-inline-end: .45em;
+	border-radius: .2em;
+	box-shadow: 0 0 0 1px hsl(220 15% 0% / .25) inset;
+	background:
+		linear-gradient(var(--color, transparent) 0 100%),
+		conic-gradient(hsl(0 0% 80%) 0 25%, white 0 50%, hsl(0 0% 80%) 0 75%, white 0) 0 0 / .7em .7em;
+}
+
+.swatch.big {
+	inline-size: 3.5em;
+	block-size: 3.5em;
+	border-radius: .3em;
+}
+
+.swatch.huge {
+	display: block;
+	inline-size: 100%;
+	block-size: 7em;
+	margin: 0;
+	border-radius: .4em;
+	background-size: auto, 1.2em 1.2em;
+}
+
+/* ---------------------------------------------------------------- sections -- */
+
+section {
+	margin: 2.5em 0;
+	padding-top: .5em;
+	border-top: 1px solid var(--hairline);
+}
+
+section > h2 {
+	font-size: 1.15em;
+	font-weight: 600;
+	letter-spacing: .01em;
+}
+
+section > p {
+	max-width: 50em;
+	color: var(--muted);
+}
+
+.result {
+	border-top: 0;
+	padding: 1.2em 1.4em;
+	border-radius: .5em;
+	background: var(--panel);
+	border: 1px solid var(--hairline);
+}
+
+.result > h2 {
+	margin-top: 0;
+}
+
+.result-grid {
+	display: grid;
+	grid-template-columns: minmax(8em, 14em) 1fr;
+	gap: 1.5em;
+	align-items: center;
+}
+
+.result-grid dl {
+	margin: 0;
+	display: grid;
+	grid-template-columns: max-content 1fr;
+	gap: .3em 1em;
+}
+
+.result-grid dt {
+	color: var(--muted);
+	font-size: 90%;
+}
+
+.result-grid dd {
+	margin: 0;
+}
+
+.browser {
+	margin-bottom: 0;
+	padding-top: .8em;
+	border-top: 1px dashed var(--hairline);
+	font-size: 90%;
+	color: var(--muted);
+}
+
+.browser.agrees b,
+.browser.agrees {
+	color: oklch(45% 0.13 150);
+}
+
+.browser.differs {
+	color: oklch(48% 0.16 55);
+}
+
+.grammar {
+	padding: .6em .9em;
+	border-radius: .3em;
+	background: var(--panel);
+	border: 1px solid var(--hairline);
+	overflow-x: auto;
+	white-space: nowrap;
+}
+
+dl.parse {
+	display: grid;
+	grid-template-columns: max-content 1fr;
+	gap: .4em 1.5em;
+}
+
+dl.parse dt {
+	font-weight: 600;
+}
+
+dl.parse dd {
+	margin: 0;
+}
+
+.note {
+	color: var(--muted);
+	font-size: 90%;
+}
+
+.notes {
+	margin: .6em 0 0;
+	padding-inline-start: 1.2em;
+	font-size: 90%;
+	color: var(--muted);
+}
+
+.callout {
+	margin-top: 1em;
+	padding: .7em 1em;
+	border-radius: .3em;
+	border-inline-start: .3em solid var(--accent);
+	background: var(--panel);
+}
+
+.steps {
+	max-width: 50em;
+	padding-inline-start: 1.4em;
+}
+
+.steps li {
+	margin-bottom: .3em;
+}
+
+.calc {
+	font-family: var(--font-code);
+	font-size: 90%;
+	line-height: 1.7;
+}
+
+/* ------------------------------------------------------------------ tables -- */
+
+.scroller {
+	overflow-x: auto;
+	margin: .8em 0;
+}
+
+table.components {
+	border-collapse: collapse;
+	font-size: 90%;
+}
+
+table.components caption {
+	text-align: start;
+	padding-bottom: .4em;
+	color: var(--muted);
+}
+
+table.components th,
+table.components td {
+	padding: .35em .8em;
+	border: 1px solid var(--hairline);
+	text-align: end;
+	white-space: nowrap;
+}
+
+table.components thead th {
+	background: var(--panel);
+	font-weight: 600;
+}
+
+table.components tbody th,
+table.components thead th:first-child {
+	text-align: start;
+	font-weight: 400;
+}
+
+table.components thead th:first-child {
+	font-weight: 600;
+}
+
+table.components td {
+	font-family: var(--font-code);
+	font-variant-numeric: tabular-nums;
+}
+
+table.components tr.muted {
+	color: var(--muted);
+	background: hsl(220 25% 99%);
+}
+
+table.components td.missing {
+	color: oklch(52% 0.16 300);
+	font-style: italic;
+}
+
+/* -------------------------------------------------------------- color cards -- */
+
+.color-cards {
+	display: grid;
+	gap: 1.2em;
+}
+
+.color-card {
+	padding: 1em 1.2em;
+	border: 1px solid var(--hairline);
+	border-radius: .4em;
+}
+
+.color-card-head {
+	display: flex;
+	align-items: center;
+	gap: 1em;
+}
+
+.written {
+	font-size: 105%;
+	font-weight: 600;
+}
+
+.pct {
+	margin: .2em 0 0;
+	font-size: 90%;
+	color: var(--muted);
+}
+
+.same-space {
+	margin: .4em 0;
+}
+
+/* -------------------------------------------------------------- iterations -- */
+
+.iteration {
+	margin: 1.2em 0;
+	padding: 1em 1.2em;
+	border: 1px solid var(--hairline);
+	border-radius: .4em;
+}
+
+.iteration h3 {
+	margin-top: 0;
+	font-size: 1em;
+	font-weight: 600;
+}
+
+.pushed {
+	margin-bottom: 0;
+	font-size: 90%;
+	color: var(--muted);
+}
+
+#probe {
+	display: none;
+}
+
+footer {
+	margin-top: 3em;
+	padding-top: 1em;
+	border-top: 1px solid var(--hairline);
+	font-size: 85%;
+	color: var(--muted);
+}
+
+@media (width < 45em) {
+	.result-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.result-grid dl {
+		grid-template-columns: 1fr;
+	}
+
+	.inputs input {
+		min-width: 100%;
+	}
+}

--- a/lr-vs-l/index.html
+++ b/lr-vs-l/index.html
@@ -7,6 +7,10 @@
 <title>Oklab vs. Oklrab interpolation</title>
 <link rel="stylesheet" href="style.css">
 
+<!-- Must come before any module script, including the one the Eleventy dev server
+     injects into <head>: an import map is rejected once a module load has started. -->
+<script src="../importmap.js"></script>
+
 </head>
 <body>
 
@@ -49,7 +53,6 @@
 	</figure>
 </div>
 
-<script src="../importmap.js"></script>
 <script type="module" src="index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds [`color-mix/`](color-mix), an app demonstrating the CSS Color 5 [`color-mix()`](https://www.w3.org/TR/css-color-5/#color-mix) function, and linked from the Tools list.

Type any legal `color-mix()` value. The app parses it, lists every color both in its origin color space and in the mixing color space, and shows each stage of [the color-mix() algorithm](https://www.w3.org/TR/css-color-5/#color-mix-result) with the value of every component:

1. The parsed function — mixing color space and hue interpolation method, noting where Oklab and `shorter` are being assumed
2. The colors, converted to the mixing space, with missing components carried forward into analogous components and powerless components flagged
3. Percentage normalization — specified sum, filling omitted percentages, forced normalization, leftover, and the resulting `alpha mult`
4. The stack-based pairwise mixing loop — combined percentage, progress `p`, hue fix-up, premultiplication, interpolation, un-premultiplication
5. The final alpha multiply

Stages that are no-ops for a given input collapse to a one-line note, so simple mixes stay readable.

## Notes

The mixing is implemented from the spec in [`colormix.js`](color-mix/colormix.js) rather than delegated to Color.js. That is partly so every intermediate value can be displayed, but also because `range()` gamut-maps its endpoints, which `color-mix()` does not. Color.js does the color parsing and all color space conversions.

The result is cross-checked against what the browser itself computes for the same input, reported as a ΔE₀₀ — useful for spotting implementation divergence.

Out-of-gamut values are never silently clipped: Color.js clips when serializing sRGB-based spaces, so those are written out longhand instead, and swatches are handed to the browser in the mixing color space (or OkLCh when out of gamut) so the browser does its own gamut mapping.

## Verification

Reproduces every worked example in the specs — CSS Color 5 §3.3, §3.4 and §3.5, and CSS Color 4 §13.3 and §13.4 — including the quoted intermediate values, not just the final colors. The `device-cmyk()` example in §3.4 is omitted, since its result depends on which ICC profile an implementation picks.

Two editorial issues in CSS Color 5 §3.4 turned up while checking, both to be handled separately:

- In the `in xyz` red/sky-blue example, the quoted component values are XYZ **D50**, not D65 (`in xyz` means `xyz-d65`). The stated final result is nonetheless correct, because D50↔D65 adaptation is a linear matrix and so commutes with a weighted average; only the three intermediate triplets are mislabelled.
- The white/black example writes results as `lch(50% 0 0)`, but hue is powerless at zero chroma, so it should be `lch(50% 0 none)` — as the spec itself writes two examples later for white.

## Second commit

[`lr-vs-l`](lr-vs-l) had `importmap.js` at the end of `<body>`. The Eleventy dev server injects its live-reload client into `<head>` as a module script, so the import map arrived after a module load had started, Firefox rejected it, and the page was blank under `npm run watch:html`. Moved into `<head>`, matching `_includes/plain.njk` and `gradients/index.html`. Verified in Firefox Nightly: 0 module requests before, ~108 after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
